### PR TITLE
ci: revert mkdocs to 1.0.4 due to table style degeneration

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Prepare build environment
       run: |
         sudo apt install python3-pip python3-dev python3-setuptools
-        sudo pip3 install -U mkdocs pygments pymdown-extensions
+        sudo pip3 install -U mkdocs==1.0.4 pygments pymdown-extensions
 
     - name: Build the document
       run: mkdocs build


### PR DESCRIPTION
See-also: https://github.com/tronprotocol/documentation-en/pull/23