### PR TITLE
Security fix: pin dependency versions and add pip-audit step

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,10 +18,15 @@ jobs:
     - name: Prepare build environment
       run: |
         sudo apt install python3-pip python3-dev python3-setuptools
-        sudo pip3 install -U pygments==2.17.2 pymdown-extensions
-        sudo pip3 install mkdocs-exclude
+        sudo pip3 install -U pygments==2.17.2 pymdown-extensions==10.14.3
+        sudo pip3 install mkdocs-exclude==1.0.2
         sudo pip3 install mkdocs-material==9.6.8
         sudo pip3 install jieba==0.42.1
+
+    - name: Audit dependencies
+      run: |
+        sudo pip3 install pip-audit==2.10.0
+        pip-audit
 
     - name: Build the document
       run: mkdocs build


### PR DESCRIPTION
## Summary                                                                    
  - Pin `pymdown-extensions==10.14.3` and `mkdocs-exclude==1.0.2` to prevent
  supply chain attacks (M-03)                                                   
  - Add `pip-audit` dependency scanning step before build to detect known
  vulnerabilities (I-05)                                                        
                                                        
## Test plan
  - [ ] Manually trigger the workflow and verify all dependencies install
  successfully
  - [ ] Verify `pip-audit` step runs and passes
  - [ ] Verify site builds and deploys correctly