### PR TITLE
docs: restore HTTP API XSS note and reorder machine-readable definitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@
 
 * **提交 Pull Request (PR)**
 
-  从您的 fork 仓库向 `tronprotocol/documentation-zh` 提交一个 Pull Request。请选择 `tronprotocol/documentation-en` 的 `master` 分支作为 **base branch**（目标分支），并选择您 fork 仓库中的对应分支作为 **compare branch**（比较分支）。
+  从您的 fork 仓库向 `tronprotocol/documentation-zh` 提交一个 Pull Request。请选择 `tronprotocol/documentation-zh` 的 `master` 分支作为 **base branch**（目标分支），并选择您 fork 仓库中的对应分支作为 **compare branch**（比较分支）。
 
 ## 常见问题 (FAQ)
 

--- a/docs/api/http/index.md
+++ b/docs/api/http/index.md
@@ -16,6 +16,14 @@
 - **`permission_id`**：交易构造接口可选；用于多签账户指定使用哪个 `Permission`。
 - **金额单位**：除 TRC-10 数量按发行精度外，其他金额一律为 sun（1 TRX = 1e6 sun）。
 
+!!! warning "XSS 安全提示"
+
+    尽管 HTTP API 通过将 `Content-Type` 设置为 `application/json` 降低了浏览器直接将响应解析为 HTML 的风险，但这并不等于完全避免 XSS。部分接口对入参并无严格校验，响应中可能回显用户可控内容（尤其当 `visible=true` 时，地址、备注等字段可能以 UTF-8 字符串原样返回）。在将 API 返回的数据渲染到页面之前，应根据输出上下文进行安全处理。
+
+    正确做法是根据输出位置选择合适的编码方式：在 HTML 文本上下文中使用 HTML 实体编码（如将 `<` 转成 `&lt;`、`>` 转成 `&gt;`、`"` 转成 `&quot;`），或直接使用前端框架自带的默认输出转义机制（如 React JSX、Vue 模板的默认转义）。如果数据被放入 URL 参数中，才应使用 `encodeURIComponent()` 这类 URL 编码方法。注意 `encodeURIComponent()` / `escape()` 属于 URL 编码或旧式编码方式，不能替代 HTML 上下文中的输出转义。
+
+    更多防护指引请参考 [OWASP XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)。
+
 ## 异常响应
 
 HTTP 状态码在**绝大多数情况下都是 200**（业务错误也通过响应体表达），客户端必须解析响应体判断成败。已知例外：

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,6 @@ nav:
         - 节点维护工具: using_javatron/toolkit.md
     - API接口:
         - 概述: api/index.md
-        - 机器可读定义: api/interface-definitions.md
         - HTTP 接口:
             - 概述: api/http/index.md
             - 账户:
@@ -252,6 +251,7 @@ nav:
                 - etherbase 地址: api/json-rpc/stub/eth_coinbase.md
                 - 节点托管账户列表: api/json-rpc/stub/eth_accounts.md
                 - 挖矿任务信息: api/json-rpc/stub/eth_getWork.md
+        - 机器可读定义: api/interface-definitions.md
     - 核心协议:
         - 波场共识: mechanism-algorithm/dpos.md
         - 超级代表: mechanism-algorithm/sr.md


### PR DESCRIPTION
## Summary

- Restore the XSS security note on the HTTP API index. This guidance existed in the original `http.md` but was dropped during the source-based API rewrite. It advises output encoding by output context (HTML entity encoding vs. URL encoding) and references the OWASP XSS Prevention Cheat Sheet. Placed next to the `visible` convention, since `visible=true` returns user-controlled text fields verbatim.
- Move the "机器可读定义" entry to the end of the API nav section (after the JSON-RPC block), so the human-facing endpoint docs come first.
- Also included: a one-line fix in `CONTRIBUTING.md` replacing a stale "documentation-en" reference with "documentation-zh".

## Test plan

- [x] `api/http/index.md` renders the XSS note as a warning admonition
- [x] mkdocs nav shows "机器可读定义" as the last item under API接口