### PR TITLE
update wallet-cli docs for 4.9.7

### DIFF
--- a/docs/clients/wallet-cli/accounts.md
+++ b/docs/clients/wallet-cli/accounts.md
@@ -192,7 +192,7 @@ TRON 账户支持灵活的权限模型（一个 owner 权限、一个可选的 w
       "type": 2,
       "permission_name": "active",
       "threshold": 2,
-      "operations": "7fff1fc0033e0000000000000000000000000000000000000000000000000000",
+      "operations": "7fff1fc0033ef30f000000000000000000000000000000000000000000000000",
       "keys": [
         { "address": "TAbc...", "weight": 1 },
         { "address": "TDef...", "weight": 1 }
@@ -204,4 +204,6 @@ TRON 账户支持灵活的权限模型（一个 owner 权限、一个可选的 w
 
 - `threshold` 是该权限授权一个操作所需的签名者总权重。
 - `operations`（仅 active 权限）是一个 32 字节的十六进制位图，用于选择该权限可执行哪些合约/操作类型。
+  上面的示例匹配 4.9.7 的默认 active 权限位图：它排除了已禁用的操作 51
+  （`ShieldedTransferContract`），同时保留 49、52 等 active 操作。
 - `witness_permission` 仅对超级代表账户有意义。

--- a/docs/clients/wallet-cli/index.md
+++ b/docs/clients/wallet-cli/index.md
@@ -5,24 +5,33 @@
 [Trident SDK](https://github.com/tronprotocol/trident)）与 TRON 节点通信，用于查询链上数据以及构建、
 签名和广播交易。少数功能（如 GasFree 代付转账）则通过 HTTP 调用相应的服务接口。
 
-它提供两种使用方式：
+它提供三种使用方式：
 
-- **交互模式（REPL）** —— 带 Tab 补全和交互式提示的人性化 shell。适合手动探索和日常钱包管理。
-- **标准 CLI 模式** —— 非交互、可脚本化的接口，具有确定的退出码和可选的 JSON 输出。适合自动化、
-  脚本、CI/CD 以及 AI 智能体。
+- **Java 交互模式（REPL）** —— 带 Tab 补全和交互式提示的人性化 shell。适合手动探索和日常钱包管理。
+- **Java 标准 CLI 模式** —— 非交互、可脚本化的接口，具有确定的退出码和可选的 JSON 输出。适合使用
+  Java JAR 的自动化和脚本。
+- **TypeScript / npm CLI** —— 4.9.7 引入的独立 Node.js CLI，以 `@tron-walletcli/wallet-cli`
+  发布。它使用 `tx send`、`account balance` 等分组命令，面向自动化、CI/CD 和 AI 智能体。
 
-本文档中的每条命令，只要在两种模式下都存在，都会同时给出两种写法。用标签页切换查看：
+下面的命令参考页主要覆盖 Java JAR 的 REPL 和标准 CLI 模式。Node.js 命令面请参见
+[TypeScript / npm CLI](typescript-cli.md)。下面用标签页对比同一个账户查询在三种入口中的写法：
 
-=== "标准 CLI"
+=== "Java 标准 CLI"
 
     ```bash
     java -jar build/libs/wallet-cli.jar --network nile get-account --address TXyz...
     ```
 
-=== "交互模式"
+=== "Java 交互模式"
 
     ```
     GetAccount TXyz...
+    ```
+
+=== "TypeScript / npm CLI"
+
+    ```bash
+    wallet-cli account info --network tron:nile --account TXyz...
     ```
 
 ## 构建

--- a/docs/clients/wallet-cli/staking.md
+++ b/docs/clients/wallet-cli/staking.md
@@ -12,14 +12,13 @@ TRON 账户质押（冻结）TRX 以获取**带宽**和**能量**，并获得投
 |------|----------|
 | `0` | BANDWIDTH（带宽） |
 | `1` | ENERGY（能量） |
-| `2` | TRON_POWER（投票权；仅 REPL 的 freeze/unfreeze，且受网络开关限制） |
+| `2` | TRON_POWER（投票权；仅 freeze/unfreeze，且受网络开关限制） |
 
-码 `2`（TRON_POWER）只被 **REPL** 的 freeze/unfreeze 命令接受 ——
-`FreezeBalance`/`UnfreezeBalance`（Stake 1.0）与 `FreezeBalanceV2`/`UnfreezeBalanceV2`（Stake 2.0）。
-即便如此也受网络开关限制：只有当链参数 `getAllowNewResourceModel` 启用时，节点才允许用码 `2` 冻结，
-而主网**并未**启用——因此实际上只有 `0`/`1` 可用。标准 CLI 中每条带 `--resource` 的命令都会在本地
-前置拒绝 `0`（BANDWIDTH）/`1`（ENERGY）以外的值并报用法错误。代理命令（两种模式）同样只接受
-`0` 或 `1`。
+码 `2`（TRON_POWER）对 freeze/unfreeze 命令受网络开关限制：
+`FreezeBalance`/`UnfreezeBalance`（Stake 1.0）、`FreezeBalanceV2`/`UnfreezeBalanceV2`（Stake 2.0）
+以及对应的标准 CLI 命令，只有在链参数 `getAllowNewResourceModel` 启用时才接受它。如果无法获取该链参数，
+4.9.7 客户端会 fail-open，让节点在广播时进行最终校验。代理命令（两种模式）始终只接受 `0` 或 `1`；
+TRON_POWER 不可代理。
 
 金额以 **SUN** 为单位（1 TRX = 1,000,000 SUN）。
 
@@ -42,8 +41,8 @@ TRON 账户质押（冻结）TRX 以获取**带宽**和**能量**，并获得投
     ```
 
     - `--amount`（必填，SUN）、`--duration`（必填，天）。
-    - `--resource`（可选，`0`/`1`，默认 `0`）。标准 CLI 只接受 `0`/`1`；若要为 TRON_POWER
-      （投票权，码 `2`）冻结，请使用 REPL 的 `FreezeBalance`。
+    - `--resource`（可选，`0`/`1`/`2`，默认 `0`）。`2` 是 TRON_POWER，仅在
+      `getAllowNewResourceModel` 启用时允许。如果设置了 `--receiver`，该操作属于代理，`2` 会被拒绝。
     - `--receiver`（可选）—— 把获得的资源代理给另一个地址。
     - `--owner`、`--multi`（可选）。
 
@@ -63,7 +62,8 @@ TRON 账户质押（冻结）TRX 以获取**带宽**和**能量**，并获得投
     java -jar build/libs/wallet-cli.jar --network nile unfreeze-balance --resource 1
     ```
 
-    - `--resource`（可选，默认 `0`）。
+    - `--resource`（可选，`0`/`1`/`2`，默认 `0`）。`2` 是 TRON_POWER，仅在
+      `getAllowNewResourceModel` 启用时允许。如果设置了 `--receiver`，该操作针对代理冻结，`2` 会被拒绝。
     - `--receiver`（可选）—— 若该资源曾被代理则必填。
     - `--owner`、`--multi`（可选）。
 
@@ -86,7 +86,9 @@ TRON 账户质押（冻结）TRX 以获取**带宽**和**能量**，并获得投
       --amount 1000000 --resource 1
     ```
 
-    - `--amount`（必填，SUN）、`--resource`（可选，默认 `0`）。
+    - `--amount`（必填，SUN）、`--resource`（可选，`0`/`1`/`2`，默认 `0`）。
+      `2` 是 TRON_POWER，仅在 `getAllowNewResourceModel` 启用时允许；如果无法获取该链参数，客户端会让节点
+      在广播时校验。
     - `--owner`、`--permission-id`、`--multi`（可选）。
 
 === "交互模式"
@@ -106,7 +108,9 @@ TRON 账户质押（冻结）TRX 以获取**带宽**和**能量**，并获得投
       --amount 1000000 --resource 1
     ```
 
-    - `--amount`（必填，SUN）、`--resource`（可选，默认 `0`）。
+    - `--amount`（必填，SUN）、`--resource`（可选，`0`/`1`/`2`，默认 `0`）。
+      `2` 是 TRON_POWER，仅在 `getAllowNewResourceModel` 启用时允许；如果无法获取该链参数，客户端会让节点
+      在广播时校验。
     - `--owner`、`--permission-id`、`--multi`（可选）。
 
 === "交互模式"

--- a/docs/clients/wallet-cli/typescript-cli.md
+++ b/docs/clients/wallet-cli/typescript-cli.md
@@ -1,0 +1,222 @@
+# TypeScript / npm CLI
+
+从 `wallet-cli` 4.9.7 开始，仓库同时提供一个面向智能体优先设计的 TypeScript CLI，并以 npm 包
+`@tron-walletcli/wallet-cli` 发布。它与本节其他页面介绍的 Java JAR 是两套命令面：Java CLI 使用
+`send-coin` 这类命令，而 TypeScript CLI 使用 `tx send` 这类分组命令。
+
+当前 TypeScript CLI 支持 TRON 主网、Nile 和 Shasta。本版本尚不支持 EVM 链。
+
+## 安装
+
+需要 Node.js 20 或更高版本。
+
+```bash
+npm install -g @tron-walletcli/wallet-cli
+wallet-cli --version
+wallet-cli --help
+```
+
+## 快速开始
+
+创建本地 HD 钱包，选择该钱包，并使用 Nile 进行测试交易：
+
+```bash
+wallet-cli create --label main
+wallet-cli list
+wallet-cli use main
+wallet-cli current
+wallet-cli config defaultNetwork tron:nile
+wallet-cli account balance
+```
+
+也可以只为某一条命令临时指定网络，而不修改默认网络：
+
+```bash
+wallet-cli account balance --network tron:nile
+```
+
+## 全局选项
+
+常用全局选项包括：
+
+| 选项 | 说明 |
+|--------|-------------|
+| <code>--output text&#124;json</code>, <code>-o</code> | 选择 text 或 JSON 输出。 |
+| `--network` | 网络 ID，例如 `tron:mainnet`、`tron:nile` 或 `tron:shasta`。 |
+| `--account` | 账户 ID、标签或地址；默认使用 `use` 设置的 active account。 |
+| `--timeout` | 每次 RPC/设备调用的超时时间，单位为毫秒。 |
+| `--verbose`, `-v` | 输出更多诊断信息。 |
+| `--wait` | 广播后轮询，直到交易 confirmed 或 failed。 |
+| `--wait-timeout` | `--wait` 轮询的上限，单位为毫秒。 |
+| `--password-stdin` | 从 stdin 读取 master password。 |
+
+命令级 stdin 标志包括 `--mnemonic-stdin`、`--private-key-stdin`、`--tx-stdin` 和
+`--message-stdin`。单次调用中只能有一个 `*-stdin` 标志消费 stdin。
+
+## 钱包和账户
+
+TypeScript CLI 默认把数据保存在 `~/.wallet-cli`。可通过 `WALLET_CLI_HOME` 隔离测试或自动化数据。
+
+```bash
+WALLET_CLI_HOME=/tmp/wallet-cli-demo wallet-cli list --output json
+```
+
+常用钱包命令：
+
+```bash
+wallet-cli create --label main
+wallet-cli import mnemonic --label imported
+wallet-cli import private-key --label hot
+wallet-cli import watch --address T... --label treasury
+wallet-cli import ledger --app tron --index 0 --label cold
+wallet-cli list
+wallet-cli use main
+wallet-cli current
+wallet-cli rename main --label primary
+wallet-cli backup primary --out ~/primary-backup.json
+```
+
+4.9.7 中，HD 子账户派生需要显式传入 seed id；该 seed id 可通过 `wallet-cli list` 查看。
+
+```bash
+wallet-cli derive --seed-id wlt_ab12cd34 --label operations
+```
+
+删除根 HD 钱包会级联删除从该根派生出的账户，并清理孤立标签。在非交互式 shell 中需要传入 `--yes`；
+否则命令会要求确认。
+
+```bash
+wallet-cli delete old --yes
+```
+
+## 交易
+
+通过 `--amount` 传入的是人类可读金额。使用 `--raw-amount` 可传入 SUN 或 token 基础单位。
+
+```bash
+wallet-cli tx send --to T... --amount 1 --dry-run
+wallet-cli tx send --to T... --amount 1 --wait
+wallet-cli tx send --to T... --token USDT --amount 5
+wallet-cli tx send --to T... --contract TR7... --amount 5
+wallet-cli tx send --to T... --asset-id 1002000 --raw-amount 1000000
+```
+
+改变链上状态的命令支持三种执行模式：
+
+| 模式 | 行为 |
+|------|----------|
+| 默认 | 构建、签名并广播。 |
+| `--dry-run` | 构建并估算，不签名、不广播。 |
+| `--sign-only` | 签名并输出交易，但不广播。 |
+
+稍后广播已签名交易：
+
+```bash
+wallet-cli tx broadcast --tx-stdin < signed.json
+```
+
+`tx status` 返回四状态模型：`confirmed`、`failed`、`pending` 或 `not_found`。
+
+```bash
+wallet-cli tx status --txid <TXID>
+wallet-cli tx info --txid <TXID> --output json
+```
+
+## 查询和签名
+
+与钱包绑定的账户查询默认使用 active account，也可以通过 `--account` 指定账户。
+
+```bash
+wallet-cli account info --output json
+wallet-cli account history --limit 10
+wallet-cli account portfolio
+wallet-cli networks
+wallet-cli block
+wallet-cli block 12345
+wallet-cli message sign --message 'hello'
+```
+
+## Token 和合约
+
+Token 地址簿内置了 USDT、USDC 等常见主网 token，也可以加入自定义 TRC-20 合约。
+
+```bash
+wallet-cli token add --contract TR7...
+wallet-cli token list
+wallet-cli token balance --contract TR7...
+wallet-cli token info --contract TR7...
+wallet-cli token remove --contract TR7...
+```
+
+合约调用使用 JSON 编码的参数描述：
+
+```bash
+wallet-cli contract info --contract TR7...
+
+wallet-cli contract call \
+  --contract T... \
+  --method 'balanceOf(address)' \
+  --params '[{"type":"address","value":"T..."}]'
+
+wallet-cli contract send \
+  --contract T... \
+  --method 'transfer(address,uint256)' \
+  --params '[{"type":"address","value":"T..."},{"type":"uint256","value":"1000000"}]' \
+  --dry-run
+
+wallet-cli contract deploy \
+  --abi '[...]' \
+  --bytecode 60... \
+  --fee-limit 1000000000 \
+  --params '[100,"T..."]' \
+  --dry-run
+```
+
+在 JSON 输出中，TypeScript CLI 的合约部署成功后，部署回执数据会包含部署出的 `contractAddress`。
+
+合约部署需要软件账户。Ledger TRON app 无法签名 `CreateSmartContract`，因此 Ledger 支持的
+账户不能使用 `wallet-cli contract deploy`。
+
+## Stake 2.0
+
+质押金额以 SUN 为单位。TypeScript CLI 提供 Stake 2.0 命令：
+
+```bash
+wallet-cli stake freeze --amount-sun 1000000 --resource energy --dry-run
+wallet-cli stake delegate --amount-sun 1000000 --receiver T... --resource energy --dry-run
+wallet-cli stake undelegate --amount-sun 1000000 --receiver T... --resource energy --dry-run
+wallet-cli stake unfreeze --amount-sun 1000000 --resource energy --dry-run
+wallet-cli stake cancel-unfreeze --dry-run
+wallet-cli stake withdraw --dry-run
+```
+
+`stake cancel-unfreeze` 需要软件账户；Ledger TRON app 无法签名 `CancelAllUnfreezeV2Contract`。
+
+## 自动化
+
+JSON 模式向 stdout 输出一个 `wallet-cli.result.v1` envelope，并使用确定的退出码：
+
+| 代码 | 含义 |
+|------|---------|
+| `0` | 成功。 |
+| `1` | 执行、鉴权、设备或链上错误。 |
+| `2` | 命令用法或参数无效。 |
+
+智能体和脚本可以发现完整命令目录与 JSON Schema，无需解析面向人的 help 文本：
+
+```bash
+wallet-cli --json-schema
+wallet-cli tx send --json-schema
+```
+
+输入 secret 时，应通过 stdin 管道传入，避免放在 argv 或导出的环境变量中：
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" | wallet-cli message sign --message 'hello' --password-stdin --output json
+printf '%s\n' "$MNEMONIC" | wallet-cli import mnemonic --label main --mnemonic-stdin
+printf '%s\n' "$PRIVATE_KEY" | wallet-cli import private-key --label hot --private-key-stdin
+```
+
+这些示例假设 shell 变量通过安全方式注入且没有 export。每次调用只能有一个 `*-stdin` 标志消费 stdin。
+`import mnemonic` 和 `import private-key` 等命令同时需要 master password 与 mnemonic/private key；
+如果通过管道传入其中一个 secret，另一个必须在 TTY 中交互输入。它们不能在单 stdin 调用中完全非交互式完成。

--- a/docs/clients/wallet-cli/typescript-cli.md
+++ b/docs/clients/wallet-cli/typescript-cli.md
@@ -1,8 +1,9 @@
 # TypeScript / npm CLI
 
-从 `wallet-cli` 4.9.7 开始，仓库同时提供一个面向智能体优先设计的 TypeScript CLI，并以 npm 包
-`@tron-walletcli/wallet-cli` 发布。它与本节其他页面介绍的 Java JAR 是两套命令面：Java CLI 使用
-`send-coin` 这类命令，而 TypeScript CLI 使用 `tx send` 这类分组命令。
+从 `wallet-cli` 仓库的 4.9.7 发布版本开始，仓库同时提供一个面向智能体优先设计的 TypeScript CLI。
+该 CLI 以 npm 包 `@tron-walletcli/wallet-cli` 发布，并采用独立的 npm 版本号；`wallet-cli --version`
+显示的是 npm 包版本。它与本节其他页面介绍的 Java JAR 是两套命令面：Java CLI 使用 `send-coin`
+这类命令，而 TypeScript CLI 使用 `tx send` 这类分组命令。
 
 当前 TypeScript CLI 支持 TRON 主网、Nile 和 Shasta。本版本尚不支持 EVM 链。
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -285,6 +285,7 @@ nav:
             - 治理: clients/wallet-cli/governance.md
             - GasFree: clients/wallet-cli/gasfree.md
             - 查询: clients/wallet-cli/query.md
+            - TypeScript / npm CLI: clients/wallet-cli/typescript-cli.md
     - 版本发布:
         - 新版本部署手册: releases/upgrade-instruction.md
         - 一致性检验: releases/signature_verification.md
@@ -396,4 +397,3 @@ plugins:
         - introduction/overview.md
         - mechanism-algorithm/shielded-TRC20-contract.md
         - mechanism-algorithm/trc10.md
-


### PR DESCRIPTION
## Summary

- Add a Chinese TypeScript/npm CLI reference page covering installation, wallet/account flows, transactions, queries, tokens, contracts, staking, JSON output, and stdin secret handling.
- Update the Chinese wallet-cli landing page and navigation to present Java REPL, Java standard CLI, and the new TypeScript/npm CLI entry point.
- Refresh 4.9.7 Java CLI details for account permission operation bitmaps and network-gated TRON_POWER staking resource handling.

## Test plan

- [x] Reviewed rendered pages locally; navigation shows the new TypeScript / npm CLI entry.
- [x] Verified tabbed examples display Java Standard CLI, Java REPL, and TypeScript / npm CLI variants.
- [x] Checked accounts and staking edits against the 4.9.7 client behavior.
- [x] Confirmed the Chinese translation matches the English source page-for-page.