### PR TITLE
align config documentation with java-tron v4.8.2

### DIFF
--- a/docs/api/http/index.md
+++ b/docs/api/http/index.md
@@ -17,8 +17,8 @@
 - **`Permission_id`**：交易构造接口可选；用于多签账户指定使用哪个 `Permission`。字段名区分大小写。
 - **金额单位**：除 TRC-10 数量按发行精度外，其他金额一律为 sun（1 TRX = 1e6 sun）。
 - **`int64_as_string`**：GET 请求可在 URL 查询参数中添加 `int64_as_string=true`。启用后，protobuf JSON 响应中的 int64 / uint64 字段会序列化为 JSON 字符串，避免 JavaScript 等客户端出现精度损失。该参数只对 GET 请求生效，不影响 POST 请求体。
-- **请求体大小**：HTTP 请求体受 `config.conf` 中 `node.http.maxMessageSize` 限制（默认 `4194304`，约 4 MiB；`0` 表示拒绝所有非空 body）。JSON-RPC 有独立的 `node.jsonrpc.maxMessageSize`。
-- **限流**：HTTP 单接口限流在 `rate.limiter.http` 中配置。全局开关 `rate.limiter.apiNonBlocking` 控制超限行为：`true` 表示立即拒绝，并返回 HTTP 200 和 `{"Error":"class java.lang.IllegalAccessException : lack of computing resources"}`；`false` 表示排队并阻塞调用方直到获得 permit。
+- **请求体大小**：HTTP 请求体受 `node.http.maxMessageSize` 限制。其默认值在 `common/src/main/resources/reference.conf` 中定义（`4194304`，约 4 MiB；`0` 表示拒绝所有非空 body），并可在节点的外部配置文件中覆盖。JSON-RPC 有独立的 `node.jsonrpc.maxMessageSize`。有关配置加载和覆盖行为，请参阅[节点配置](../../using_javatron/configuration.md)。
+- **限流**：HTTP 单接口限流在 `rate.limiter.http` 中配置。全局开关 `rate.limiter.apiNonBlocking` 控制 permit 的获取方式：`true` 表示在没有可用 permit 时立即拒绝；`false` 表示 QPS 和单 IP QPS 策略会阻塞等待令牌，而 `GlobalPreemptibleAdapter` 最多等待两秒以获取并发 permit。请求被拒绝时返回 HTTP 200 和 `{"Error":"class java.lang.IllegalAccessException : lack of computing resources"}`。
 
 !!! warning "XSS 安全提示"
 
@@ -32,10 +32,10 @@
 
 HTTP 状态码在**绝大多数情况下都是 200**（业务错误也通过响应体表达），客户端必须解析响应体判断成败。已知例外：
 
-- 接口被节点配置 `disabledApiList` 显式禁用时，由 `HttpApiAccessFilter` 直接返回 **HTTP 404**，响应体 `{"Error": "this API is unavailable due to config"}`。
+- 接口被节点配置 `node.disabledApi` 显式禁用时，由 `HttpApiAccessFilter` 直接返回 **HTTP 404**，响应体 `{"Error": "this API is unavailable due to config"}`。
 - 请求体超过 `node.http.maxMessageSize` 时，共享 HTTP `SizeLimitHandler` 可能会在目标 servlet 处理请求前直接返回 **HTTP 413**（`Payload Too Large`）。如果请求已经进入 servlet，并由 servlet 内部的 `Util.checkBodySize` 检查到 body 超限，则接口会按自身的异常响应格式返回；部分接口仍可能是 **HTTP 200** 加错误响应体。
 - 启用非阻塞限流且共享 `RateLimiterServlet` 无法获得 permit 时，会在目标 servlet 运行前返回 **HTTP 200**，响应体为 `{"Error":"class java.lang.IllegalAccessException : lack of computing resources"}`。这是共享层错误，而非接口业务错误。
-- 节点以 lite fullnode 模式启动且未开启 `openHistoryQueryWhenLiteFN` 时，由 `LiteFnQueryHttpFilter` 对约 24 个历史查询接口（`getblockbynum` / `gettransactionbyid` / `gettransactioninfobyid` / `gettransactioninfobyblocknum` / `getblockbyid` / `getblockbylatestnum` / `getblockbylimitnext` / `gettransactioncountbyblocknum` 等）返回 **HTTP 200**，但响应体是裸字符串 `this API is closed because this node is a lite fullnode`（**非 JSON**），客户端朴素 `JSON.parse` 会抛错，需先按字符串前缀识别。
+- 节点以 lite fullnode 模式启动且未开启 `node.openHistoryQueryWhenLiteFN` 时，由 `LiteFnQueryHttpFilter` 对约 24 个历史查询接口（`getblockbynum` / `gettransactionbyid` / `gettransactioninfobyid` / `gettransactioninfobyblocknum` / `getblockbyid` / `getblockbylatestnum` / `getblockbylimitnext` / `gettransactioncountbyblocknum` 等）返回 **HTTP 200**，但响应体是裸字符串 `this API is closed because this node is a lite fullnode`（**非 JSON**），客户端朴素 `JSON.parse` 会抛错，需先按字符串前缀识别。
 - 其它由 servlet 容器/反向代理产生的网络层错误（502、504、连接拒绝等）不在本文档范围。
 
 <!-- BEGIN GENERATED HTTP ERROR CATALOG -->
@@ -50,7 +50,7 @@ Catalog ID 和重试分类由 `openapi.yaml` 的 `x-tron-error-model` 定义。�
 | `HTTP_RATE_LIMITED` | HTTP 200 且 `$.Error` 包含 `lack of computing resources` | 共享 servlet 限流器拒绝了请求。 | 是 | `SAFE_WITH_BACKOFF` | 使用带抖动的指数退避自动重试；响应不包含 Retry-After header。 |
 | `HTTP_SERVLET_EXCEPTION` | HTTP 200 加自由文本 `$.Error` | servlet 在 JavaTronError 中返回了异常类和消息。 | 否 | `UNKNOWN` | 检查具体 Error 文本和接口上下文；不得仅根据该兜底分类自动重试。 |
 | `HTTP_API_DISABLED` | HTTP 404 且 `$.Error` = `this API is unavailable due to config` | 节点配置禁用了该接口。 | 否 | `AFTER_STATE_CHANGE` | 使用已启用该接口的节点，或等待节点配置变更。 |
-| `HTTP_LITE_FULLNODE_HISTORY_DISABLED` | HTTP 200 加裸文本 `this API is closed because this node is a lite fullnode` | lite FullNode 拒绝了历史区块或交易查询。 | 否 | `AFTER_STATE_CHANGE` | 使用 full node，或等待 `openHistoryQueryWhenLiteFN` 配置变更。 |
+| `HTTP_LITE_FULLNODE_HISTORY_DISABLED` | HTTP 200 加裸文本 `this API is closed because this node is a lite fullnode` | lite FullNode 拒绝了历史区块或交易查询。 | 否 | `AFTER_STATE_CHANGE` | 使用 full node，或等待 `node.openHistoryQueryWhenLiteFN` 配置变更。 |
 | `HTTP_REQUEST_TOO_LARGE` | HTTP 413（`text/html`） | 请求超过 `node.http.maxMessageSize`。 | 否 | `AFTER_REQUEST_REBUILD` | 缩小请求体后重新提交。 |
 | `RETURN_SIGERROR` | `$.code` 或 `$.result.code` = `SIGERROR` | 交易签名无效。 | 否 | `NEVER` | 修正签名并重新签名。 |
 | `RETURN_CONTRACT_VALIDATE_ERROR` | `$.code` 或 `$.result.code` = `CONTRACT_VALIDATE_ERROR` | 合约校验失败。 | 否 | `AFTER_REQUEST_REBUILD` | 修正参数、余额或权限后重构请求。 |

--- a/docs/api/json-rpc/index.md
+++ b/docs/api/json-rpc/index.md
@@ -9,9 +9,9 @@
 | FullNode JSON-RPC | `8545` | `node.jsonrpc.httpFullNodeEnable` | 全量数据库（最新块即可见） |
 | Solidity JSON-RPC | `8555` | `node.jsonrpc.httpSolidityEnable` | 仅固化数据 |
 
-端口可通过 `node.jsonrpc.httpFullNodePort` / `httpSolidityPort` 覆盖（参见 `framework/src/main/resources/config.conf` 的 `jsonrpc {}` 段）。
+端口可通过 `node.jsonrpc.httpFullNodePort` / `node.jsonrpc.httpSolidityPort` 覆盖。其默认值在 `common/src/main/resources/reference.conf` 的 `node.jsonrpc` 配置块中定义。
 
-> **默认关闭**：`config.conf` 中 `jsonrpc {}` 块的所有开关默认注释掉，`Args` 中 `httpFullNodeEnable` / `httpSolidityEnable` 均为 `false`（见 `Args.java`）。需在配置中显式 `httpFullNodeEnable = true` / `httpSolidityEnable = true` 才会随节点启动。Solidity JSON-RPC 服务还要求当前进程为 FullNode（不是独立的 SolidityNode 进程，见 `JsonRpcServiceOnSolidity.java`）。
+> **默认关闭**：`reference.conf` 将 `node.jsonrpc.httpFullNodeEnable` 和 `node.jsonrpc.httpSolidityEnable` 均设置为 `false`。必须在节点的外部配置文件中将相应开关显式设置为 `true`，服务才会随节点启动。Solidity JSON-RPC 服务还要求当前进程为 FullNode（不是独立的 SolidityNode 进程，见 `JsonRpcServiceOnSolidity.java`）。
 
 URL 路径恒为 `/jsonrpc`（见 `FullNodeJsonRpcHttpService.java`）。
 
@@ -73,7 +73,9 @@ Catalog ID 和重试分类由 `openrpc.json` 的 `x-tron-error-model` 定义。�
 }
 ```
 
-> **注意**：`disabledApi` 配置项**不影响 JSON-RPC**（见 `config.conf` 注释 "but not jsonrpc"）。要禁用 JSON-RPC，请关闭对应 `httpFullNodeEnable` / `httpSolidityEnable`。
+> **注意**：`node.disabledApi` **不影响 JSON-RPC**。要禁用 JSON-RPC 服务，请将相应的 `node.jsonrpc.httpFullNodeEnable` 或 `node.jsonrpc.httpSolidityEnable` 开关设置为 `false`。
+
+有关配置优先级、所有 API 服务端口以及重启要求，请参阅[节点配置](../../using_javatron/configuration.md)。
 
 ## 节点信息 / 链身份
 
@@ -130,7 +132,7 @@ Catalog ID 和重试分类由 `openrpc.json` 的 `x-tron-error-model` 定义。�
 | [`eth_getFilterChanges`](filter/eth_getFilterChanges.md) | 拉取并清空 filter 增量 |
 | [`eth_getFilterLogs`](filter/eth_getFilterLogs.md) | 拉取 log filter 全量（不清空） |
 
-filter 相关默认限额（见 `config.conf` 的 `jsonrpc {}` 段）：
+JSON-RPC 限制和 filter 相关默认值（在 `common/src/main/resources/reference.conf` 的 `node.jsonrpc` 配置块中定义）：
 
 | 配置项 | 默认值 | 含义 |
 |---|---|---|

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ java-tron 是 TRON 网络的官方 Java 客户端实现，由 TRON 协议团队�
     部署、监控、维护 java-tron 节点的运维指南。
 
     - [部署 java-tron](using_javatron/installing_javatron.md)
+    - [节点配置](using_javatron/configuration.md)
     - [节点监控](using_javatron/metrics.md)
     - [升级到新版本](releases/upgrade-instruction.md)
     - [私链网络](using_javatron/private_network.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -17,6 +17,7 @@
 ## 运行节点
 
 - [部署 java-tron](https://tronprotocol.github.io/documentation-zh/using_javatron/installing_javatron/)：硬件要求、JDK 先决条件、源码编译、启动全节点/固化节点/超级代表节点、JVM 调优。
+- [节点配置](https://tronprotocol.github.io/documentation-zh/using_javatron/configuration/)：配置来源解析与优先级、网络与存储设置、API 服务与端口、限流、出块凭证以及动态重载行为。
 - [备份与恢复](https://tronprotocol.github.io/documentation-zh/using_javatron/backup_restore/)：节点数据库的快照与恢复。
 - [轻全节点](https://tronprotocol.github.io/documentation-zh/using_javatron/litefullnode/)：运行与维护裁剪后的低占用节点。
 - [私链网络](https://tronprotocol.github.io/documentation-zh/using_javatron/private_network/)：搭建私有 TRON 链。

--- a/docs/releases/upgrade-instruction.md
+++ b/docs/releases/upgrade-instruction.md
@@ -18,7 +18,7 @@
 
 #### 方式一：下载可执行文件 (推荐)
 
-1.  访问 [java-tron GitHub Releases](https://github.com/tronprotocol/java-tron/releases) 页面，下载最新版本的 `FullNode.jar` 可执行文件。
+1.  访问 [java-tron GitHub Releases](https://github.com/tronprotocol/java-tron/releases) 页面，根据系统架构下载最新的可执行文件：x86-64 使用 `FullNode-x64.jar`，ARM64 使用 `FullNode-aarch64.jar`。完成签名校验后，将下载的文件重命名为 `FullNode.jar`，供后续步骤使用。
 2.  **安全校验**：为确保文件的完整性和安全性，请务必根据 [java-tron 一致性校验](signature_verification.md) 文档对下载的 JAR 文件进行签名校验。
 
 #### 方式二：从源码编译

--- a/docs/using_javatron/backup_restore.md
+++ b/docs/using_javatron/backup_restore.md
@@ -75,7 +75,7 @@ tar xzvf output-directory.20220628152402.etgz
 
 **注意：**
 
-- **LevelDB** 和 **RocksDB** 数据不允许混用。FullNode 的数据库类型通过配置文件中的 `db.engine` 配置项指定，可选值为 `LEVELDB` 或 `ROCKSDB`。如果您拥有 LevelDB 格式的数据，但希望以 RocksDB 引擎启动节点，可以使用 toolkit 中的 [数据转换工具](toolkit.md#data-conversion-tool) 将 LevelDB 数据转换为 RocksDB 格式。
+- **LevelDB** 和 **RocksDB** 数据不允许混用。FullNode 的数据库类型通过配置文件中的 `storage.db.engine` 配置项指定，可选值为 `LEVELDB` 或 `ROCKSDB`。如果您拥有 LevelDB 格式的数据，但希望以 RocksDB 引擎启动节点，可以使用 toolkit 中的 [数据转换工具](toolkit.md#data-conversion-tool) 将 LevelDB 数据转换为 RocksDB 格式。
 - 内部交易通过配置文件中的 `vm.saveInternalTx` 或者 `vm.saveFeaturedInternalTx` 配置项开启/关闭。只有开启 `vm.saveInternalTx`，才会保存内部交易，如果 `saveFeaturedInternalTx` 也同时开启，则会保存所有类型的内部交易，否则，只保存 `call`、`create`、`suicide` 交易。影响接口：[`gettransactioninfobyid`](../api/http/block-and-tx-query/gettransactioninfobyid.md)
 - 配置项 `vm.saveCancelAllUnfreezeV2Details` 会额外把带宽 / 能量 / TRON Power 的取消额度以 `extra` 字段的形式记录到 `CANCELALLUNFREEZEV2` 操作码生成的内部交易上。该配置仅在 `vm.saveInternalTx` 与 `vm.saveFeaturedInternalTx` 同时开启时才会生效。请注意，上表中包含内部交易的官方快照源节点并未开启该配置，仅开启了 `vm.saveInternalTx` 与 `vm.saveFeaturedInternalTx`。
 - 账户历史余额通过配置文件中的 `storage.balance.history.lookup` 配置项开启/关闭。影响接口：[`getaccountbalance`](../api/http/account/getaccountbalance.md)

--- a/docs/using_javatron/configuration.md
+++ b/docs/using_javatron/configuration.md
@@ -32,7 +32,7 @@ java-tron 内置了两个用途不同的配置文件：
 - [完整默认值（`reference.conf`）](https://github.com/tronprotocol/java-tron/blob/master/common/src/main/resources/reference.conf)
 - [主网配置模板（`config.conf`）](https://github.com/tronprotocol/java-tron/blob/master/framework/src/main/resources/config.conf)
 
-对于 Nile 或其他网络，应使用对应网络的配置模板，而不是只修改网络名称。节点发现、P2P 版本、种子节点和创世块配置必须全部指向同一个网络。支持的网络配置模板请参阅[部署 java-tron](installing_javatron.md#network-types)。
+对于 Nile 或其他网络，应使用为该网络提供的配置模板。节点发现、P2P 版本、种子节点和创世块配置必须全部指向同一个网络。支持的网络配置模板请参阅[部署 java-tron](installing_javatron.md#network-types)。
 
 ## 使用外部配置启动节点
 

--- a/docs/using_javatron/configuration.md
+++ b/docs/using_javatron/configuration.md
@@ -1,0 +1,208 @@
+# 节点配置
+
+java-tron 使用 [HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) 配置文件。命令行选项 `-c` 用于指定配置名称或路径；java-tron 可以将其解析为文件系统中的文件，也可以解析为应用程序中打包的资源。
+
+本指南介绍当前的配置模型、节点运维者最常用的设置，以及哪些变更需要重启节点。
+
+## 配置文件与优先级 { #configuration-files-and-precedence }
+
+java-tron 内置了两个用途不同的配置文件：
+
+| 文件 | 用途 |
+|---|---|
+| `common/src/main/resources/reference.conf` | 定义完整的默认值集合，并始终作为回退配置。 |
+| `framework/src/main/resources/config.conf` | 提供内置的主网部署配置和运行参数覆盖。当解析出的名称为 `config.conf`，且文件系统中不存在对应文件时，加载该文件。 |
+
+配置按照以下顺序解析和应用：
+
+1. 配置名称取自 `-c` 传入的值；如果省略 `-c`，FullNode 默认使用 `config.conf`。
+2. java-tron 检查该名称是否指向文件系统中已存在的文件。相对路径以进程的当前工作目录为基准解析。
+3. 如果文件不存在，java-tron 会查找同名的 classpath 资源。例如，文件系统中没有 `config.conf` 时，`-c config.conf` 仍可加载 JAR 中内置的 `config.conf`。
+4. 如果两种来源都不存在，节点会因配置路径错误而启动失败。
+5. 加载选中的配置，并以 `reference.conf` 作为回退配置。
+6. 对应的命令行参数覆盖已加载的配置值。
+7. 最后应用特定平台的约束。
+
+无论是通过 `-c` 指定，还是自动发现的 `./config.conf`，外部配置文件都**不会**继承内置 `config.conf` 中的值。因此，即使所有省略的配置项仍会从 `reference.conf` 获取默认值，精简的外部配置文件也可能与内置配置产生不同的运行行为。
+
+特定平台的约束可能覆盖已经解析的配置。尤其是 ARM64 仅支持 RocksDB，因此无论配置文件或 CLI 如何设置，java-tron 都会强制将 `storage.db.engine` 设置为 `ROCKSDB`。
+
+生产部署应从目标网络的当前配置模板开始，并保留该网络必需的特定配置。当前 java-tron 源文件如下：
+
+- [完整默认值（`reference.conf`）](https://github.com/tronprotocol/java-tron/blob/master/common/src/main/resources/reference.conf)
+- [主网配置模板（`config.conf`）](https://github.com/tronprotocol/java-tron/blob/master/framework/src/main/resources/config.conf)
+
+对于 Nile 或其他网络，应使用对应网络的配置模板，而不是只修改网络名称。节点发现、P2P 版本、种子节点和创世块配置必须全部指向同一个网络。支持的网络配置模板请参阅[部署 java-tron](installing_javatron.md#network-types)。
+
+## 使用外部配置启动节点
+
+通过 `-c` 指定外部配置文件，并通过 `-d` 选择节点的输出目录：
+
+```bash
+java -jar FullNode.jar \
+  -c /etc/java-tron/mainnet.conf \
+  -d /var/lib/java-tron
+```
+
+要运行出块节点，请添加 `--witness`：
+
+```bash
+java -jar FullNode.jar \
+  --witness \
+  -c /etc/java-tron/mainnet.conf \
+  -d /var/lib/java-tron
+```
+
+如果命令行选项和配置文件控制同一行为，命令行选项会覆盖配置文件中的值，但仍受上述特定平台约束的限制。
+
+HOCON 同时支持嵌套对象和点分隔键。例如，以下内容只是配置片段，并非完整的主网配置：
+
+```hocon
+storage.db.directory = "database"
+
+node {
+  listen.port = 18888
+
+  discovery {
+    enable = true
+    persist = true
+  }
+
+  http {
+    fullNodeEnable = true
+    fullNodePort = 8090
+  }
+
+  jsonrpc {
+    httpFullNodeEnable = false
+    httpFullNodePort = 8545
+  }
+}
+```
+
+配置键名称和值类型必须与 `reference.conf` 完全一致。尤其要注意：布尔值使用不加引号的 `true` / `false`，数值使用数字，文本使用带引号的字符串，列表使用方括号。
+
+## 网络与对等节点配置
+
+主要的 P2P 配置如下：
+
+| 配置路径 | 用途 |
+|---|---|
+| `node.p2p.version` | 标识 P2P 协议使用的 TRON 网络。 |
+| `node.listen.port` | 节点接受 P2P 连接的 TCP 端口。 |
+| `node.discovery.enable` | 启用节点发现。 |
+| `node.discovery.persist` | 持久化已发现的节点。 |
+| `node.discovery.external.ip` | 向对等节点广播指定的公网 IP 地址。 |
+| `seed.node.ip.list` | 提供引导节点。 |
+| `node.active` | 列出节点应主动维持连接的对等节点。 |
+| `node.passive` | 列出受信任的入站对等节点地址。 |
+| `node.maxConnections` | 限制对等节点连接总数。 |
+| `node.maxConnectionsWithSameIp` | 限制来自同一 IP 地址的对等节点连接数。 |
+
+当节点需要接受入站连接时，应在主机防火墙中开放 P2P 监听端口。如果节点位于 NAT 后方，请确保对外广播的地址、端口转发和节点配置保持一致。
+
+有关节点发现、种子节点、主动/被动节点、IPv6 和连接数限制的示例，请参阅[连接 TRON 网络指南](connecting_to_tron.md)。
+
+## 存储与输出目录
+
+`-d` / `--output-directory` 选项用于选择节点输出根目录，`storage.db.directory` 用于选择该根目录下的数据库目录。例如：
+
+```bash
+java -jar FullNode.jar -c /etc/java-tron/mainnet.conf -d /data/fullnode
+```
+
+```hocon
+storage {
+  db.engine = "LEVELDB"
+  db.sync = false
+  db.directory = "database"
+}
+```
+
+在此示例中，默认数据库位置位于 `/data/fullnode/database` 下。同一台机器上的每个 java-tron 进程都应使用不同的 `-d` 目录，不能让两个正在运行的进程指向同一个数据库。
+
+`storage.properties` 列表可以为各个数据库分别设置路径和 LevelDB 调优参数。每个条目都必须包含 `name`；`path` 同时适用于 LevelDB 和 RocksDB，而 `blockSize`、`writeBufferSize`、`cacheSize` 和 `maxOpenFiles` 仅适用于 LevelDB。
+
+更改数据库引擎或性能设置前，请参阅[数据库配置指南](../architecture/database.md)。有关运行数据的处理，请参阅[备份与恢复](backup_restore.md)和[节点维护工具](toolkit.md)。
+
+## API 服务与端口 { #api-services-and-ports }
+
+以下默认值来自 `reference.conf`。外部配置可以覆盖每项服务的启用开关和端口。
+
+| 服务 | 启用开关 | 端口配置 | 默认值 |
+|---|---|---|---|
+| FullNode HTTP | `node.http.fullNodeEnable` | `node.http.fullNodePort` | 启用，`8090` |
+| Solidity HTTP | `node.http.solidityEnable` | `node.http.solidityPort` | 启用，`8091` |
+| PBFT HTTP | `node.http.PBFTEnable` | `node.http.PBFTPort` | 启用，`8092` |
+| FullNode gRPC | `node.rpc.enable` | `node.rpc.port` | 启用，`50051` |
+| Solidity gRPC | `node.rpc.solidityEnable` | `node.rpc.solidityPort` | 启用，`50061` |
+| PBFT gRPC | `node.rpc.PBFTEnable` | `node.rpc.PBFTPort` | 启用，`50071` |
+| FullNode JSON-RPC | `node.jsonrpc.httpFullNodeEnable` | `node.jsonrpc.httpFullNodePort` | 禁用，`8545` |
+| Solidity JSON-RPC | `node.jsonrpc.httpSolidityEnable` | `node.jsonrpc.httpSolidityPort` | 禁用，`8555` |
+| PBFT JSON-RPC | `node.jsonrpc.httpPBFTEnable` | `node.jsonrpc.httpPBFTPort` | 禁用，`8565` |
+
+请求和消息大小限制分别配置：
+
+- `node.http.maxMessageSize` 控制 HTTP 请求体大小。
+- `node.rpc.maxMessageSize` 控制 gRPC 消息大小。
+- `node.jsonrpc.maxMessageSize` 控制 JSON-RPC 请求体大小。
+- `node.jsonrpc.maxBatchSize`、`maxResponseSize` 和 filter 限制用于约束 JSON-RPC 工作负载。
+
+使用 `node.disabledApi` 可以禁用指定的 HTTP、gRPC 或 PBFT 方法，但它不会禁用 JSON-RPC 方法；要禁用 JSON-RPC 服务，请使用对应的 `node.jsonrpc.*Enable` 开关。
+
+不要将管理类接口或交易构造接口直接暴露给不受信任的网络。应通过主机或网络控制限制访问，并在需要时将公共服务置于配置适当的网关之后。有关各协议的具体行为，请参阅 [HTTP API](../api/http/index.md) 和 [JSON-RPC API](../api/json-rpc/index.md) 指南。
+
+## 限流
+
+API 限制在 `rate.limiter` 下配置：
+
+- `rate.limiter.http` 定义各 servlet 的 HTTP 规则。
+- `rate.limiter.rpc` 定义各方法的 gRPC 规则。
+- `rate.limiter.global.qps` 限制 HTTP 和 gRPC 请求总量。
+- `rate.limiter.global.ip.qps` 限制来自单一源 IP 的请求。
+- `rate.limiter.global.api.qps` 提供各接口的默认限制。
+- `rate.limiter.apiNonBlocking` 选择以非阻塞或阻塞方式获取 permit。
+
+当 `rate.limiter.apiNonBlocking` 为 `true` 时，超限请求会立即被拒绝；为 `false` 时，QPS 和单 IP QPS 策略会阻塞等待令牌。`GlobalPreemptibleAdapter` 的行为不同：它最多等待两秒以获取并发 permit，超过两秒仍未获得时拒绝请求。
+
+P2P 消息限制独立配置在 `rate.limiter.p2p` 下。
+
+## 出块凭证
+
+使用 `--witness` 启动的节点需要访问出块账户的签名私钥。生产部署应优先使用 `localwitnesskeystore`。`localwitness` 会将私钥直接存储在配置文件中，因此必须格外注意文件保护。
+
+应将配置文件和 keystore 文件的访问权限限制为节点的操作系统用户，不要将密钥提交到源码仓库，也不要在测试环境中重复使用生产私钥。有关说明，请参阅[启动出块节点](installing_javatron.md#starting-a-block-production-node)和[使用 keystore 指定私钥](installing_javatron.md#keystore-password)。
+
+## 事件订阅与监控
+
+事件投递由 `event.subscribe` 控制。其配置用于选择原生队列或事件插件、插件路径或目标服务器，以及启用的触发器主题。完整配置请参阅[事件订阅](../architecture/event.md)。
+
+Prometheus 监控配置位于 `node.metrics.prometheus` 下，包括启用开关和监听端口。采集和仪表板说明请参阅[节点监控](metrics.md)。
+
+## 动态配置重载
+
+动态重载默认关闭：
+
+```hocon
+node.dynamicConfig {
+  enable = true
+  checkInterval = 600
+}
+```
+
+`checkInterval` 的单位是秒。由于重载服务会监视所选文件的修改，应当配合磁盘上的配置文件使用该功能，配置文件可以通过 `-c` 指定，也可以是自动发现的 `./config.conf`。
+
+目前动态重载只会应用 `node.active` 和 `node.passive` 的变更。其他配置（包括端口、存储、API 开关、限流以及 `node.fastForward`）都需要重启进程。重载成功消息使用 `DEBUG` 级别，默认会被 `app` logger 的 `INFO` 级别隐藏。编辑文件后，可以为 `app` logger 启用 `DEBUG` 以查看重载消息，也可以通过节点运行状态验证更新后的对等连接。
+
+## 验证配置变更
+
+在生产环境中应用配置前：
+
+1. 保留一份可恢复的最近正常配置文件。
+2. 检查 HOCON 的大括号、逗号、列表语法、键名拼写和值类型。
+3. 确认配置文件属于目标网络，并包含该网络必需的覆盖值。
+4. 确认所有配置的监听端口都可用且已获防火墙放行。
+5. 启动或重启节点，并检查 `logs/tron.log` 中与配置、端口绑定、数据库和对等连接相关的错误。
+6. 验证区块同步以及所有计划开放的 API。
+
+如果配置修改似乎没有生效，请先确认实际选择的配置来源：显式指定的 `-c` 路径、隐式的 `./config.conf`，或内置的 `config.conf`。随后重启节点，除非修改的是动态重载支持的两个对等节点列表之一。

--- a/docs/using_javatron/connecting_to_tron.md
+++ b/docs/using_javatron/connecting_to_tron.md
@@ -15,11 +15,11 @@ TRON 网络分为以下几类：
 
 ## 基础配置网络
 
-通过修改 [配置文件](https://github.com/tronprotocol/java-tron/blob/develop/framework/src/main/resources/config.conf) 中的以下关键项，可将 java-tron 节点接入指定网络：
+通过修改当前[主网配置文件](https://github.com/tronprotocol/java-tron/blob/master/framework/src/main/resources/config.conf)中的以下关键项，可将 java-tron 节点接入指定网络。
 
 ### 网络标识（P2P 网络 ID）
 
-网络ID(`p2p.version`): 表示希望加入的网络。相关配置项：
+P2P 网络 ID（`node.p2p.version`）指定希望加入的网络。主网配置如下：
 
 ```properties
 node {
@@ -229,9 +229,9 @@ java-tron 使用 [Kademlia](https://zh.wikipedia.org/wiki/Kademlia) 协议发现
 
 种子节点也由两部分组成：
 
-#### 配置的 `seed.node` 
+#### 配置的 `seed.node.ip.list`
 
-使用 `seed.node` 初始化网络连接。应设置为在线稳定的全节点。每个条目可以使用 IPv4 地址、带方括号的 IPv6 地址或域名：
+使用 `seed.node.ip.list` 初始化网络连接。应设置为在线稳定的全节点。每个条目可以使用 IPv4 地址、带方括号的 IPv6 地址或域名：
 
 
 ```properties
@@ -248,7 +248,7 @@ seed.node = {
 }
 ```
 
-对于TRON主网，可以使用 [社区公共节点](https://developers.tron.network/docs/networks#public-node) 作为种子节点。如果想要获取最新的`seed.node`，可以在官方的 [配置文件](https://github.com/tronprotocol/java-tron/blob/master/framework/src/main/resources/config.conf) 查看。
+对于 TRON 主网，可以使用[社区公共节点](https://developers.tron.network/docs/networks#public-node)作为种子节点。如果想要获取最新的 `seed.node.ip.list`，可以在官方的[配置文件](https://github.com/tronprotocol/java-tron/blob/master/framework/src/main/resources/config.conf)中查看。
 如果网卡支持 ipv6，可以使用上述列表中的 ipv6 地址格式的种子节点，将注释符 `#` 去掉即可。
 
 #### 对等节点配置中的域名
@@ -295,7 +295,7 @@ node {
 
 节点的连接数量由以下几个参数共同控制，通常需要配合调优：
 
-- `node.maxConnections`：节点的最大连接数（默认值：30）。当连接数达到该上限后，来自非可信节点的被动连接会被拒绝。可信节点是指 IP 出现在 `node.passive`、`node.active` 或 `fastForward` 中的节点（这三处的 IP 都会被加入可信列表）。主动连接不受该限制约束：对 `node.active` 中配置的节点的主动连接，仅受 `node.active` 列表大小限制；对通过节点发现协议发现的节点的主动连接，由 `minConnections` 和 `minActiveConnections` 驱动（见下文）。
+- `node.maxConnections`：节点的最大连接数（默认值：30）。当连接数达到该上限后，来自非可信节点的被动连接会被拒绝。可信节点是指 IP 出现在 `node.passive`、`node.active` 或 `node.fastForward` 中的节点（这三处的 IP 都会被加入可信列表）。主动连接不受该限制约束：对 `node.active` 中配置的节点的主动连接，仅受 `node.active` 列表大小限制；对通过节点发现协议发现的节点的主动连接，由 `minConnections` 和 `minActiveConnections` 驱动（见下文）。
 - `node.minConnections`：期望维持的最小总连接数，包含主动连接和被动连接（默认值：8）。当总连接数低于该值时，节点会向已发现的节点发起主动连接以补足。
 - `node.minActiveConnections`：期望维持的对已发现节点的最小主动连接数（默认值：3）。即使总连接数已经达到或超过 `minConnections`，节点仍会持续向已发现的节点发起主动连接，直到该阈值被满足。
 - `node.maxConnectionsWithSameIp`：允许来自同一 IP 地址的最大连接数（默认值：2），用于缓解来自单一 IP 的滥用。

--- a/docs/using_javatron/installing_javatron.md
+++ b/docs/using_javatron/installing_javatron.md
@@ -105,7 +105,7 @@ uname -m
 
 全节点作为 TRON 网络的入口，通过 HTTP 和 RPC API 提供完整接口。客户端可借助这些端点执行资产转账、部署智能合约并调用链上逻辑。全节点必须接入 TRON 网络，才能参与共识与交易处理。
 
-### TRON 网络类型
+### TRON 网络类型 { #network-types }
 
 TRON 网络主要分为以下几类：
 
@@ -125,11 +125,11 @@ TRON 网络主要分为以下几类：
 
 ### 启动全节点连接主网 { #starting-a-fullnode-on-the-tron-main-network }
 
-以下是启动 **主网全节点** 的命令，使用默认内置的主网配置文件：
+如果当前工作目录中不存在 `./config.conf`，以下命令将使用 JAR 中内置的 `config.conf` 启动主网 FullNode。如果存在 `./config.conf`，java-tron 会优先加载该文件。为避免歧义，可通过 `-c` 指定明确路径；完整的解析顺序请参阅[节点配置](configuration.md#configuration-files-and-precedence)。
 
-`
-nohup java -jar build/libs/FullNode.jar -c framework/src/main/resources/config.conf &
-`
+```bash
+nohup java -jar build/libs/FullNode.jar &
+```
 
 *   `nohup ... &`：在后台运行命令并忽略挂断信号。
 

--- a/docs/using_javatron/litefullnode.md
+++ b/docs/using_javatron/litefullnode.md
@@ -13,7 +13,7 @@
 - **基于状态快照启动**：轻节点不从创世区块开始同步，而是直接加载一个仅包含全网最新状态和最近 65,536 个区块数据的状态快照。该区块数量为代码中的固定常量，无法通过配置修改。该值 65,536（= 2^16）与 TRON 交易的引用区块窗口一致：每笔交易的 `ref_block_hash` 必须指向最近 65,536 个区块中的某一个，否则该交易将无法通过TAPOS校验。因此轻节点必须保留至少这么多最近区块，才能验证新接收到的交易。
 - **显著的资源优势**：由于初始数据量远小于全节点，轻节点具有占用磁盘空间小、启动速度快的突出优点。
 - **提供部分全节点的 API**：默认情况下，轻节点为节省资源禁用了对历史数据（快照范围之外）的查询。其中不支持的 API 请参考 [HTTP](https://github.com/tronprotocol/java-tron/blob/master/framework/src/main/java/org/tron/core/services/filter/LiteFnQueryHttpFilter.java) 和 [gRPC](https://github.com/tronprotocol/java-tron/blob/master/framework/src/main/java/org/tron/core/services/filter/LiteFnQueryGrpcInterceptor.java)。
-- **功能可扩展**：如果需要开启这些不支持的 API，在配置文件中可以通过配置 `openHistoryQueryWhenLiteFN = true` 来开启。由于轻节点启动后，其保存的数据与全节点完全相同，所以开启该配置项后，所有被过滤的 API 将被重新开放。但快照起始高度之前的历史数据依然无法查询。
+- **功能可扩展**：如果需要开启这些不支持的 API，可在配置文件中设置 `node.openHistoryQueryWhenLiteFN = true`。由于轻节点启动后，其保存的数据与全节点完全相同，所以开启该配置项后，所有被过滤的 API 将被重新开放。但快照起始高度之前的历史数据依然无法查询。
 
 因此，如果应用场景仅需进行区块同步、处理广播交易，轻节点是更高效的选择。
 

--- a/docs/using_javatron/private_network.md
+++ b/docs/using_javatron/private_network.md
@@ -32,7 +32,7 @@
 
 2. 获取 java-tron 客户端
     
-     - 从 [Java-tron GitHub Releases](https://github.com/tronprotocol/java-tron/releases) 页面下载最新的 `FullNode.jar`。
+     - 从 [java-tron GitHub Releases](https://github.com/tronprotocol/java-tron/releases) 页面下载适用于系统架构的最新 FullNode JAR：x86-64 使用 `FullNode-x64.jar`，ARM64 使用 `FullNode-aarch64.jar`，并将下载的文件重命名为 `FullNode.jar`。
     - 将下载的 `JAR` 文件分别复制到两个节点目录中。
 
      ```bash
@@ -42,7 +42,8 @@
 
 3. 准备配置文件
 
-    - 下载官方提供的配置文件模板 ([config.conf](https://github.com/tronprotocol/java-tron/blob/develop/framework/src/main/resources/config.conf))，并修改 `p2p.version `为 **11111** 和 **20180622** 以外的任何值。
+    - 下载当前的 [`framework/src/main/resources/config.conf`](https://github.com/tronprotocol/java-tron/blob/master/framework/src/main/resources/config.conf)。
+    - 将 `node.p2p.version` 修改为未被公共网络使用的正整数。当前公共网络 ID 为：主网 `11111`、Nile `201910292`、Shasta `1`。
     - 将其分别复制到两个节点目录中，并重命名以作区分。
 
       ```bash
@@ -61,10 +62,10 @@
     | :-------- | :-------- | :-------- | :-------- |
     | `localwitness`     | 账户私钥     | 不需填值     |  用于签名区块的私钥，仅产块节点需要。     |
     | `genesis.block.witnesses`	     | SR 地址     | 与 SR 配置值相同 | 创世块相关的配置   |
-    | `genesis.block.Assets`     | 给特定账户预置 TRX。将预先准备的账户地址写入并随意指定其 TRX 的余额。可以直接修改原来已有账户的 `address` 字段，其它字段不需要修改；或者在末尾添加新账户信息    | 与 SR 配置值相同     | 创世块相关的配置     |
-    | `p2p.version`     | 11111 之外的任意正整数     | 与 SR 配置值相同      | SR 和 FullNode 需相同，只有相同 version 的节点才能握手成功     |
-    | `seed.node`     | 不需填值     | 将 `ip.list` 设置为 SR 的 IP 地址和 SR 配置文件中的 `listen.port` 端口号    | 能够让 FullNode 与 SR node 建立连接并同步数据     |
-    | `needSyncCheck`     | `false`     | `true`     | 第 1 个 SR 设置 `needSyncCheck` 为 `false`，其他设置为 `true`      |
+    | `genesis.block.assets`     | 给特定账户预置 TRX。将预先准备的账户地址写入并按需指定其 TRX 余额    | 与 SR 配置值相同     | 创世块相关的配置     |
+    | `node.p2p.version`     | 除 `11111`、`201910292` 和 `1` 之外的任意正整数     | 与 SR 配置值相同      | 只有 `node.p2p.version` 相同的节点才能完成 P2P 握手     |
+    | `seed.node.ip.list`     | 列表留空     | 按 `SR_IP:SR_P2P_PORT` 格式添加 SR 节点，其中端口使用 SR 的 `node.listen.port` 配置值    | 使 FullNode 与 SR 节点建立连接并同步数据     |
+    | `block.needSyncCheck`     | `false`     | `true`     | 第 1 个 SR 将 `block.needSyncCheck` 设置为 `false`，其他 SR 设置为 `true`      |
     | `node.discovery.enable`     | `true`     | `true`     | 如果配置成 `false`，则当前节点不会被其他节点发现     |
     |`block.proposalExpireTime`|`600000` |与 SR 配置值相同  |默认提案过期时间是 3 天：259200000(ms)；由于逻辑上强制提案最少需要经历一个完整的维护期时间间隔，所以如果希望提案快速通过，需要将该项和维护期时间间隔项同时设置成小值|
     |`block.maintenanceTimeInterval`|`300000`| 与 SR 配置值相同  | 维护期时间间隔，默认是 6 小时：21600000(ms)|
@@ -74,9 +75,12 @@
 5. 调整网络端口 (如需)    
     修改配置文件中的端口号，将 SR 和 FullNode 的配置成不相同的端口号。此步骤仅在同一台机器上运行多个节点时是必需的，以避免端口冲突。否则，可跳过此步。
     
-    * `listen.port` ：P2P 监听端口
-    * `http` 端口： HTTP 监听端口
-    * `rpc` 端口： RPC 监听端口
+    * `node.listen.port`：P2P 监听端口
+    * `node.http.fullNodePort`、`node.http.solidityPort` 和 `node.http.PBFTPort`：HTTP 监听端口
+    * `node.rpc.port`、`node.rpc.solidityPort` 和 `node.rpc.PBFTPort`：gRPC 监听端口
+    * `node.jsonrpc.httpFullNodePort`、`node.jsonrpc.httpSolidityPort` 和 `node.jsonrpc.httpPBFTPort`：启用相应服务时使用的 JSON-RPC 监听端口
+
+    对应的启用开关和默认值请参阅[节点配置中的端口表](configuration.md#api-services-and-ports)。
 
 6. 启动节点
     超级代表（产块节点）和普通全节点的启动命令略有不同。
@@ -105,7 +109,7 @@
 
      * **方式一：通过配置文件设置 (适用于初始部署)**  
 
-        一些网络参数可以通过配置文件直接设置，这些网络参数可以在 [此处](https://github.com/tronprotocol/java-tron/blob/develop/common/src/main/java/org/tron/core/Constant.java) 查看。
+        一些网络参数可以通过配置文件直接设置，当前定义可在 [`Constant.java`](https://github.com/tronprotocol/java-tron/blob/master/common/src/main/java/org/tron/core/Constant.java) 中查看。
       
          **示例**：在 `.conf` 文件中添加以下 `committee` 块来开启多签和合约创建:
       
@@ -171,4 +175,3 @@
       需要注意的是，具有相互依赖关系的网络参数不能包含在同一个提案中，正确的方法是将它们分成不同的提案，并注意它们的顺序。
      
      
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
         - 入门: getting_started/getting_started_with_javatron.md
     - 使用java-tron:
         - 部署: using_javatron/installing_javatron.md
+        - 节点配置: using_javatron/configuration.md
         - 备份和恢复: using_javatron/backup_restore.md
         - 轻节点: using_javatron/litefullnode.md
         - 私链网络: using_javatron/private_network.md


### PR DESCRIPTION
## Summary

- Add the Chinese translation of the centralized Node Configuration guide and its navigation entries.
- Align the Chinese HTTP, JSON-RPC, network connection, private network, Lite FullNode, backup, and deployment documentation with java-tron v4.8.2.
- Document architecture-specific FullNode release artifacts and synchronize configuration keys, defaults, and loading behavior with the English documentation.

## Why

The Chinese documentation is the translated counterpart of the authoritative English documentation and needs to stay aligned with its java-tron v4.8.2 configuration updates.

## Related PR

- English documentation: https://github.com/tronprotocol/documentation-en/pull/644

## Impact

Chinese-speaking node operators receive the same configuration reference, corrected key paths, service defaults, and deployment guidance as readers of the English documentation.

## Validation

- `mkdocs build --strict`
- `git diff --check`
- Verified the generated cross-page anchors.
