### PR TITLE
docs(tron-grid): 添加 OpenChainBench TRON RPC 基准测试参考

### DIFF
--- a/docs/clients/tron-grid.md
+++ b/docs/clients/tron-grid.md
@@ -4,6 +4,8 @@
 
 TronGrid提供运行在云端的客户端, 因而你自己本地不需要运行节点。TronGrid提供负载均衡的，安全的，可靠的的节点访问API。
 
+如需独立对比公共 TRON JSON-RPC 端点的延迟与可靠性（TronGrid 及社区提供商如 dRPC、PublicNode），可参考 [OpenChainBench TRON RPC 基准测试](https://openchainbench.com/benchmarks/tron-rpc)。数据每 60 秒从 3 个地区（美东、欧西、新加坡）采集，发布 p50/p90/p99 延迟与成功率，遵循 CC BY 4.0 协议并开源采集工具。
+
 TronGrid支持两种类型的API调用：
 
 - FullNode & SolidityNode api


### PR DESCRIPTION
## 摘要

在 TronGrid 介绍部分添加第三方 RPC 基准测试参考，引导开发者查看 [OpenChainBench TRON RPC 基准测试](https://openchainbench.com/benchmarks/tron-rpc)，以获得公共 TRON JSON-RPC 端点的独立性能对比。

## 适合放置的原因

TronGrid 页面是开发者选择托管 TRON API 的自然入口。OpenChainBench 每 60 秒从三个地区（美东、欧西、新加坡）探测 TRON JSON-RPC 兼容端点（`/jsonrpc`），发布 p50/p90/p99 延迟与成功率，数据遵循 CC BY 4.0 协议并开源采集工具。当前测量的提供商：TronGrid（`api.trongrid.io/jsonrpc`）、dRPC（`tron.drpc.org`）和 PublicNode（`tron.publicnode.com/jsonrpc`）。

## 变更内容

在 Introduction 部分的 TronGrid 服务描述之后新增一段。未修改现有内容。

## 利益申明

我是 OpenChainBench 的维护者，如不符合文档风格，欢迎修改或删除该引用。