### PR TITLE
align wallet-cli docs with v4.10.0 and restructure wallet-cli docs

### DIFF
--- a/docs/clients/wallet-cli/accounts.md
+++ b/docs/clients/wallet-cli/accounts.md
@@ -12,7 +12,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile create-account --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile create-account --address TXyz...
     ```
 
     - `--address`（必填）—— 要激活的地址。
@@ -29,7 +29,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-account --name "my account"
+    java -jar java/build/libs/wallet-cli.jar --network nile update-account --name "my account"
     ```
 
     - `--name`（必填）—— 新的账户名称。
@@ -48,7 +48,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile set-account-id --id myaccountid
+    java -jar java/build/libs/wallet-cli.jar --network nile set-account-id --id myaccountid
     ```
 
     - `--id`（必填）—— 要设置的账户 ID。
@@ -67,7 +67,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-account --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-account --address TXyz...
     ```
 
     - `--address`（必填）。无需鉴权。
@@ -83,7 +83,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-account-by-id --id myaccountid
+    java -jar java/build/libs/wallet-cli.jar --network nile get-account-by-id --id myaccountid
     ```
 
     - `--id`（必填）。无需鉴权。
@@ -101,7 +101,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar get-address
+    java -jar java/build/libs/wallet-cli.jar get-address
     ```
 
     需要鉴权（它上报活动钱包的地址）。
@@ -118,10 +118,10 @@
 
     ```bash
     # 查询某个显式地址的余额（无需鉴权）
-    java -jar build/libs/wallet-cli.jar --network nile get-balance --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-balance --address TXyz...
 
     # 查询活动钱包的余额（需要鉴权）
-    java -jar build/libs/wallet-cli.jar --network nile get-balance
+    java -jar java/build/libs/wallet-cli.jar --network nile get-balance
     ```
 
     - `--address`（可选）。若提供则无需鉴权；若省略则读取活动钱包余额，需要鉴权。
@@ -150,7 +150,7 @@ TRON 账户支持灵活的权限模型（一个 owner 权限、一个可选的 w
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-account-permission \
+    java -jar java/build/libs/wallet-cli.jar --network nile update-account-permission \
       --owner TXyz... --permissions '<permission-json>'
     ```
 
@@ -204,6 +204,6 @@ TRON 账户支持灵活的权限模型（一个 owner 权限、一个可选的 w
 
 - `threshold` 是该权限授权一个操作所需的签名者总权重。
 - `operations`（仅 active 权限）是一个 32 字节的十六进制位图，用于选择该权限可执行哪些合约/操作类型。
-  上面的示例匹配 4.9.7 的默认 active 权限位图：它排除了已禁用的操作 51
-  （`ShieldedTransferContract`），同时保留 49、52 等 active 操作。
+  上面的示例匹配默认 active 权限位图：它排除了已禁用的操作 51（`ShieldedTransferContract`），
+  同时保留 49、52 等 active 操作。
 - `witness_permission` 仅对超级代表账户有意义。

--- a/docs/clients/wallet-cli/gasfree.md
+++ b/docs/clients/wallet-cli/gasfree.md
@@ -14,7 +14,7 @@ nonce/余额等细节。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile gas-free-info --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile gas-free-info --address TXyz...
     ```
 
     - `--address`（可选）—— 默认为当前钱包的地址。提供 `--address` 时无需鉴权；省略时使用当前钱包，
@@ -36,7 +36,7 @@ JSON 模式下，响应的 `data` 包含所提交请求的 `gas_free_id`。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile gas-free-transfer \
+    java -jar java/build/libs/wallet-cli.jar --network nile gas-free-transfer \
       --to TXyz... --amount 1000000
     ```
 
@@ -55,7 +55,7 @@ JSON 模式下，响应的 `data` 包含所提交请求的 `gas_free_id`。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile gas-free-trace --id <traceId>
+    java -jar java/build/libs/wallet-cli.jar --network nile gas-free-trace --id <traceId>
     ```
 
     - `--id`（必填）。无需鉴权。

--- a/docs/clients/wallet-cli/governance.md
+++ b/docs/clients/wallet-cli/governance.md
@@ -14,7 +14,7 @@ TRON 治理：注册和更新见证人（超级代表候选人）、投票、管
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile create-witness --url https://my-sr.example
+    java -jar java/build/libs/wallet-cli.jar --network nile create-witness --url https://my-sr.example
     ```
 
     - `--url`（必填）。`--owner`、`--multi`（可选）。
@@ -32,7 +32,7 @@ TRON 治理：注册和更新见证人（超级代表候选人）、投票、管
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-witness --url https://my-sr.example
+    java -jar java/build/libs/wallet-cli.jar --network nile update-witness --url https://my-sr.example
     ```
 
     - `--url`（必填）。`--owner`、`--multi`（可选）。
@@ -48,7 +48,7 @@ TRON 治理：注册和更新见证人（超级代表候选人）、投票、管
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile list-witnesses
+    java -jar java/build/libs/wallet-cli.jar --network nile list-witnesses
     ```
 
 === "交互模式"
@@ -72,7 +72,7 @@ GetPaginatedNowWitnessList offset limit
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile vote-witness \
+    java -jar java/build/libs/wallet-cli.jar --network nile vote-witness \
       --votes "TWitnessA... 100 TWitnessB... 50"
     ```
 
@@ -94,7 +94,7 @@ GetPaginatedNowWitnessList offset limit
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile withdraw-balance
+    java -jar java/build/libs/wallet-cli.jar --network nile withdraw-balance
     ```
 
     - `--owner`、`--multi`（可选）。
@@ -112,7 +112,7 @@ GetPaginatedNowWitnessList offset limit
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-reward --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-reward --address TXyz...
     ```
 
     - `--address`（必填）。无需鉴权。
@@ -130,7 +130,7 @@ GetPaginatedNowWitnessList offset limit
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-brokerage --address TWitness...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-brokerage --address TWitness...
     ```
 
     - `--address`（必填）。无需鉴权。
@@ -148,7 +148,7 @@ GetPaginatedNowWitnessList offset limit
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-brokerage --brokerage 20
+    java -jar java/build/libs/wallet-cli.jar --network nile update-brokerage --brokerage 20
     ```
 
     - `--brokerage`（必填，0–100）。`--owner`、`--multi`（可选）。
@@ -171,7 +171,7 @@ GetPaginatedNowWitnessList offset limit
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile create-proposal \
+    java -jar java/build/libs/wallet-cli.jar --network nile create-proposal \
       --parameters "9 1 18 1"
     ```
 
@@ -189,7 +189,7 @@ GetPaginatedNowWitnessList offset limit
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile approve-proposal --id 42 --approve true
+    java -jar java/build/libs/wallet-cli.jar --network nile approve-proposal --id 42 --approve true
     ```
 
     - `--id`（必填）、`--approve`（必填，`true` 表示添加批准 / `false` 表示撤回批准）。
@@ -210,7 +210,7 @@ GetPaginatedNowWitnessList offset limit
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile delete-proposal --id 42
+    java -jar java/build/libs/wallet-cli.jar --network nile delete-proposal --id 42
     ```
 
     - `--id`（必填）。`--owner`、`--multi`（可选）。
@@ -226,7 +226,7 @@ GetPaginatedNowWitnessList offset limit
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile list-proposals
+    java -jar java/build/libs/wallet-cli.jar --network nile list-proposals
     ```
 
 === "交互模式"
@@ -240,7 +240,7 @@ GetPaginatedNowWitnessList offset limit
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile list-proposals-paginated --offset 0 --limit 20
+    java -jar java/build/libs/wallet-cli.jar --network nile list-proposals-paginated --offset 0 --limit 20
     ```
 
     - `--offset`（必填）、`--limit`（必填）。
@@ -256,7 +256,7 @@ GetPaginatedNowWitnessList offset limit
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-proposal --id 42
+    java -jar java/build/libs/wallet-cli.jar --network nile get-proposal --id 42
     ```
 
     - `--id`（必填）。

--- a/docs/clients/wallet-cli/index.md
+++ b/docs/clients/wallet-cli/index.md
@@ -1,25 +1,25 @@
 # wallet-cli
 
 `wallet-cli` 是 TRON 网络的命令行钱包，官方仓库为
-[tronprotocol/wallet-cli](https://github.com/tronprotocol/wallet-cli)。它在本地管理密钥和账户，主要通过 gRPC（基于
-[Trident SDK](https://github.com/tronprotocol/trident)）与 TRON 节点通信，用于查询链上数据以及构建、
-签名和广播交易。少数功能（如 GasFree 代付转账）则通过 HTTP 调用相应的服务接口。
+[tronprotocol/wallet-cli](https://github.com/tronprotocol/wallet-cli)。它在本地管理密钥和账户，
+并连接 TRON 服务，用于查询链上数据以及构建、签名和广播交易。
 
-它提供三种使用方式：
+仓库提供两种实现：
 
-- **Java 交互模式（REPL）** —— 带 Tab 补全和交互式提示的人性化 shell。适合手动探索和日常钱包管理。
-- **Java 标准 CLI 模式** —— 非交互、可脚本化的接口，具有确定的退出码和可选的 JSON 输出。适合使用
-  Java JAR 的自动化和脚本。
-- **TypeScript / npm CLI** —— 4.9.7 引入的独立 Node.js CLI，以 `@tron-walletcli/wallet-cli`
-  发布。它使用 `tx send`、`account balance` 等分组命令，面向自动化、CI/CD 和 AI 智能体。
+- **[Java CLI](java-cli.md)** —— 原始的全功能实现。它既提供面向用户的交互式 REPL，也提供供脚本
+  调用 Java JAR 的非交互式标准 CLI。
+- **[TypeScript / npm CLI](typescript-cli.md)** —— 面向智能体优先设计的 Node.js 实现，以
+  `@tron-walletcli/wallet-cli` 发布，采用分组命令、确定的退出码和结构化 JSON 输出。
 
-下面的命令参考页主要覆盖 Java JAR 的 REPL 和标准 CLI 模式。Node.js 命令面请参见
-[TypeScript / npm CLI](typescript-cli.md)。下面用标签页对比同一个账户查询在三种入口中的写法：
+## 入口对比
+
+两个界面都可以查询账户数据。Java CLI 接受任意地址，而 TypeScript CLI 操作的是本地钱包中已经
+保存的账户：
 
 === "Java 标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-account --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-account --address TXyz...
     ```
 
 === "Java 交互模式"
@@ -31,170 +31,18 @@
 === "TypeScript / npm CLI"
 
     ```bash
-    wallet-cli account info --network tron:nile --account TXyz...
+    wallet-cli account info --network tron:nile
     ```
 
-## 构建
+    该命令使用活动账户。可以通过 `--account` 传入本地钱包中已有的账户 ID、标签或地址，选择其他
+    已保存的账户。
 
-`wallet-cli` 使用 Gradle 构建，需要 **Java 8**。
+## 选择实现
 
-```bash
-# 构建项目（同时把 protobuf 源码生成到 src/main/gen/）
-./gradlew build
+| 实现 | 命令风格 | 适用场景 |
+|------|----------|----------|
+| [Java CLI](java-cli.md) | `GetAccount` 等交互式命令，或 `get-account` 等标准 CLI 命令 | 完整的 TRON 钱包功能、手动操作以及 Java JAR 集成 |
+| [TypeScript / npm CLI](typescript-cli.md) | `account info`、`tx send` 等分组命令 | 自动化、CI/CD、结构化 JSON 集成以及 AI 智能体 |
 
-# 构建 fat JAR（输出：build/libs/wallet-cli.jar）
-./gradlew shadowJar
-```
-
-执行 `shadowJar` 之后，即可用生成的 JAR 运行钱包：
-
-```bash
-java -jar build/libs/wallet-cli.jar
-```
-
-## 运行
-
-### 交互模式（REPL）
-
-不带任何命令启动即进入交互式 shell。下面两种方式均可：
-
-```bash
-./gradlew run
-# 或者，使用已构建的 JAR：
-java -jar build/libs/wallet-cli.jar
-```
-
-随后在提示符下输入命令（例如 `Login`、`GetBalance`、`SendCoin ...`）。命令名不区分大小写，并支持
-Tab 补全。输入 `Help` 列出所有命令，或输入 `Help <Command>` 查看某条命令的详细说明。
-
-### 标准 CLI 模式
-
-在命令行上传入一条命令（及其选项）。进程执行这一条命令、打印结果后退出：
-
-```bash
-java -jar build/libs/wallet-cli.jar --network nile get-balance --address TXyz...
-java -jar build/libs/wallet-cli.jar --output json --network nile get-account --address TXyz...
-```
-
-标准 CLI 的命令名采用 kebab-case（`get-account`、`send-coin`）；大多数命令同时接受去掉连字符的
-别名（`getaccount`、`sendcoin`）。并非每条命令都注册了这种别名 —— 例如 `alias-*` 系列命令只能用
-带连字符的形式。
-
-此外还有一条 `help` 命令，用于查看单条命令的用法：
-
-```bash
-java -jar build/libs/wallet-cli.jar help --command send-coin
-```
-
-## 全局选项（标准 CLI）
-
-执行修饰类全局选项由 `GlobalOptions` 解析，可以写在命令名**之前或之后**。顶层模式选择器
-有更严格的位置规则，具体说明如下。
-
-| 选项 | 取值 | 说明 |
-|--------|--------|-------------|
-| `--network` | `main`、`nile`、`shasta`、`custom` | 选择要连接的网络。 |
-| `--grpc-endpoint` | `host:port` | 覆盖 gRPC 端点（配合 `--network custom` 使用）。 |
-| `--output` | `text`（默认）、`json` | 输出格式。 |
-| `--wallet` | 名称或路径 | 按名称或路径选择特定的钱包 keystore。 |
-| `--quiet` | 标志 | 抑制非必要的提示性输出。 |
-| `--verbose` | 标志 | 开启调试日志。（与 `--quiet` 冲突。） |
-| `--password-stdin` | 标志 | 从 stdin 读取钱包密码（覆盖 `MASTER_PASSWORD`）。 |
-| `--interactive` | 标志 | 启动交互式 REPL，而非执行某条命令。 |
-| `--help`、`-h` | 标志 | 显示全局帮助，或某条命令的帮助。（`help --command <name>` 命令作用相同。） |
-| `--version` | 标志 | 打印版本信息。 |
-
-说明：
-
-- 执行修饰类选项 `--network`、`--grpc-endpoint`、`--output`、`--wallet`、`--quiet`、
-  `--verbose` 和 `--password-stdin` 可在命令名之前或之后识别。
-- 顶层模式选择器 `--version` 和 `--interactive` 必须写在命令名之前；出现在命令之后时，
-  会被视为命令自身的参数。
-- `--help` 和 `-h` 出现在命令之前时请求全局帮助，出现在命令之后时请求该命令的帮助。
-- 带取值的全局选项（`--output`、`--network`、`--wallet` 和 `--grpc-endpoint`）既可将取值
-  作为下一个 token 给出（`--network nile`），也可内联给出（`--network=nile`）。
-- 带取值的选项不可重复出现；未知的全局选项会被拒绝。
-
-## 鉴权（标准 CLI）
-
-标准 CLI 模式是非交互的，因此从不提示输入密码。构建并签名交易的命令（本文档中标注为**需要鉴权**）
-会自动完成鉴权：
-
-1. 钱包密码从环境变量 `MASTER_PASSWORD` 读取；当传入 `--password-stdin` 时则从 **stdin** 读取
-   （stdin 优先）。
-2. keystore 从 `Wallet/` 目录加载。可用 `--wallet <name|path>` 选择特定钱包，或用
-   `set-active-wallet` 设置一个**活动钱包**（见 [钱包管理](wallet-management.md)）。
-
-大多数只读查询命令不需要鉴权。例外是作用于当前钱包的查询：`get-address` 始终需要鉴权，
-`get-balance` / `get-usdt-balance` / `gas-free-info` 在省略 `--address` 时需要鉴权
-（见 [查询](query.md) 和 [GasFree](gasfree.md)）。
-
-```bash
-export MASTER_PASSWORD='your-wallet-password'
-java -jar build/libs/wallet-cli.jar --network nile send-coin --to TXyz... --amount 1000000
-```
-
-REPL 的鉴权方式不同：通过 `Login` / `LoginAll` 交互式登录，会话保持解锁状态。见
-[钱包管理](wallet-management.md)。
-
-## JSON 输出与退出码（标准 CLI）
-
-使用 `--output json` 时，每条命令都会在 stdout 上输出单个 JSON 信封。
-
-成功：
-
-```json
-{
-  "success": true,
-  "data": { }
-}
-```
-
-错误：
-
-```json
-{
-  "success": false,
-  "error": "execution_error",
-  "message": "human-readable explanation"
-}
-```
-
-其他规则：
-
-- 广播交易的命令会在 `data` 中包含交易 id `txid`（仅限单签广播）。
-- `deploy-contract` 会在 `data` 中包含部署得到的 `contract_address`。
-- 当某个选项的别名被解析时，信封会包含一个 `meta.resolved` 数组描述解析结果（见
-  [钱包管理](wallet-management.md) 中的别名系统）。
-
-退出码：
-
-| 码 | 含义 |
-|------|---------|
-| `0` | 成功。 |
-| `1` | 执行错误（`"error": "execution_error"` 等）。 |
-| `2` | 用法错误（`"error": "usage_error"` —— 标志错误、缺少必填选项等）。 |
-
-这使得标准 CLI 可安全地用脚本驱动：检查退出码，并从 stdout 解析这唯一的 JSON 对象即可。
-
-## 网络与配置
-
-各网络的默认节点端点以及其他默认值，位于 `src/main/resources/config.conf`（HOCON 格式）。
-`--network` 标志在 `main`、`nile`（测试网）、`shasta`（测试网）和 `custom` 之间选择。对于
-`custom`，用 `--grpc-endpoint host:port` 提供端点。
-
-在 REPL 中，用 `SwitchNetwork` 切换网络，用 `CurrentNetwork` 查看当前网络。
-
-## 命令参考
-
-命令按领域分组：
-
-- [钱包管理](wallet-management.md) —— 创建/导入/导出钱包、登录、备份、锁定、活动钱包、别名。
-- [账户](accounts.md) —— 链上账户的创建与更新、余额、权限。
-- [质押与资源](staking.md) —— 冻结/解冻（v1 与 v2）、资源代理、奖励。
-- [交易](transactions.md) —— 转账 TRX/资产/USDT、多签签名、广播。
-- [智能合约](smart-contracts.md) —— 部署、触发、常量调用、能量预估。
-- [TRC-10 资产](trc10.md) —— 发行、更新、参与、转账以及查询 TRC-10 代币。
-- [治理](governance.md) —— 见证人、投票、提案、佣金、奖励提取。
-- [GasFree](gasfree.md) —— 免 gas（代付）的 USDT 转账。
-- [查询](query.md) —— 区块、交易、链参数、价格、节点及工具类命令。
+两种实现有各自独立的安装与运行要求。请继续阅读 [Java CLI 概览](java-cli.md) 或
+[TypeScript / npm CLI 概览](typescript-cli.md)。

--- a/docs/clients/wallet-cli/java-cli.md
+++ b/docs/clients/wallet-cli/java-cli.md
@@ -1,0 +1,175 @@
+# Java CLI
+
+`wallet-cli` 的 Java 实现提供两种入口：
+
+- **交互模式（REPL）** —— 带 Tab 补全和交互式提示的人性化 shell。
+- **标准 CLI 模式** —— 非交互式接口，具有确定的退出码和可选的 JSON 输出。
+
+两种入口使用同一个 Java JAR，并共同覆盖 Java 实现的功能面，但有些命令只在其中一种模式下可用。
+有关基于 npm 的实现，请参见 [TypeScript / npm CLI](typescript-cli.md)。
+
+## 构建
+
+Java 实现位于仓库的 `java/` 目录中，使用 Gradle 构建，需要 **Java 8**。下面的命令均以仓库根目录
+为工作目录，以便与本节其他位置使用的路径保持一致。
+
+```bash
+git clone https://github.com/tronprotocol/wallet-cli.git
+cd wallet-cli
+
+# 构建项目和 fat JAR
+./java/gradlew -p java build shadowJar
+```
+
+执行 `shadowJar` 后，可以使用生成的 JAR 运行钱包：
+
+```bash
+java -jar java/build/libs/wallet-cli.jar
+```
+
+## 运行
+
+### 交互模式（REPL）
+
+不带任何命令启动即进入交互式 shell。下面两种方式均可：
+
+```bash
+./java/gradlew -p java run
+# 或者，使用已构建的 JAR：
+java -jar java/build/libs/wallet-cli.jar
+```
+
+随后在提示符下输入命令（例如 `Login`、`GetBalance`、`SendCoin ...`）。命令名不区分大小写，
+并支持 Tab 补全。输入 `Help` 列出所有命令，或输入 `Help <Command>` 查看某条命令的详细说明。
+
+### 标准 CLI 模式
+
+在命令行上传入一条命令及其选项。进程执行该命令、打印结果后退出：
+
+```bash
+java -jar java/build/libs/wallet-cli.jar --network nile get-balance --address TXyz...
+java -jar java/build/libs/wallet-cli.jar --output json --network nile get-account --address TXyz...
+```
+
+标准 CLI 的命令名采用 kebab-case（`get-account`、`send-coin`）；大多数命令同时接受去掉连字符的
+别名（`getaccount`、`sendcoin`）。并非每条命令都注册了这种别名——例如 `alias-*` 系列命令只能用
+带连字符的形式。
+
+此外还有一条 `help` 命令，用于查看单条命令的用法：
+
+```bash
+java -jar java/build/libs/wallet-cli.jar help --command send-coin
+```
+
+## 全局选项（标准 CLI）
+
+执行修饰类全局选项由 `GlobalOptions` 解析，可以写在命令名**之前或之后**。顶层模式选择器有更严格的
+位置规则，具体说明如下。
+
+| 选项 | 取值 | 说明 |
+|------|------|------|
+| `--network` | `main`、`nile`、`shasta`、`custom` | 选择要连接的网络。 |
+| `--grpc-endpoint` | `host:port` | 覆盖 gRPC 端点（配合 `--network custom` 使用）。 |
+| `--output` | `text`（默认）、`json` | 输出格式。 |
+| `--wallet` | 名称或路径 | 按名称或路径选择特定的钱包 keystore。 |
+| `--quiet` | 标志 | 抑制非必要的提示性输出。 |
+| `--verbose` | 标志 | 开启调试日志。（与 `--quiet` 冲突。） |
+| `--password-stdin` | 标志 | 从 stdin 读取钱包密码（覆盖 `MASTER_PASSWORD`）。 |
+| `--interactive` | 标志 | 启动交互式 REPL，而非执行某条命令。 |
+| `--help`、`-h` | 标志 | 显示全局帮助，或某条命令的帮助。（`help --command <name>` 命令作用相同。） |
+| `--version` | 标志 | 打印版本信息。 |
+
+说明：
+
+- 执行修饰类选项 `--network`、`--grpc-endpoint`、`--output`、`--wallet`、`--quiet`、
+  `--verbose` 和 `--password-stdin` 可在命令名之前或之后识别。
+- 顶层模式选择器 `--version` 和 `--interactive` 必须写在命令名之前；出现在命令之后时，会被视为
+  命令自身的参数。
+- `--help` 和 `-h` 出现在命令之前时请求全局帮助，出现在命令之后时请求该命令的帮助。
+- 带取值的全局选项（`--output`、`--network`、`--wallet` 和 `--grpc-endpoint`）既可将取值作为
+  下一个 token 给出（`--network nile`），也可内联给出（`--network=nile`）。
+- 带取值的选项不可重复出现；未知的全局选项会被拒绝。
+
+## 鉴权（标准 CLI）
+
+标准 CLI 模式是非交互的，因此从不提示输入密码。构建并签名交易的命令（本文档中标注为**需要鉴权**）
+会自动完成鉴权：
+
+1. 钱包密码从环境变量 `MASTER_PASSWORD` 读取；当传入 `--password-stdin` 时则从 **stdin** 读取
+   （stdin 优先）。
+2. keystore 从 `Wallet/` 目录加载。可用 `--wallet <name|path>` 选择特定钱包，或用
+   `set-active-wallet` 设置一个**活动钱包**（见 [钱包管理](wallet-management.md)）。
+
+大多数只读查询命令不需要鉴权。例外是作用于当前钱包的查询：`get-address` 始终需要鉴权，
+`get-balance` / `get-usdt-balance` / `gas-free-info` 在省略 `--address` 时需要鉴权
+（见 [查询](query.md) 和 [GasFree](gasfree.md)）。
+
+```bash
+export MASTER_PASSWORD='your-wallet-password'
+java -jar java/build/libs/wallet-cli.jar --network nile send-coin --to TXyz... --amount 1000000
+```
+
+REPL 的鉴权方式不同：通过 `Login` / `LoginAll` 交互式登录，会话保持解锁状态。见
+[钱包管理](wallet-management.md)。
+
+## JSON 输出与退出码（标准 CLI）
+
+使用 `--output json` 时，每条命令都会在 stdout 上输出单个 JSON 信封。
+
+成功：
+
+```json
+{
+  "success": true,
+  "data": { }
+}
+```
+
+错误：
+
+```json
+{
+  "success": false,
+  "error": "execution_error",
+  "message": "human-readable explanation"
+}
+```
+
+其他规则：
+
+- 广播交易的命令会在 `data` 中包含交易 ID `txid`（仅限单签广播）。
+- `deploy-contract` 会在 `data` 中包含部署得到的 `contract_address`。
+- 当某个选项的别名被解析时，信封会包含一个 `meta.resolved` 数组描述解析结果（见
+  [钱包管理](wallet-management.md) 中的别名系统）。
+
+退出码：
+
+| 码 | 含义 |
+|----|------|
+| `0` | 成功。 |
+| `1` | 执行错误（`"error": "execution_error"` 等）。 |
+| `2` | 用法错误（`"error": "usage_error"`——标志错误、缺少必填选项等）。 |
+
+这使得标准 CLI 可安全地用脚本驱动：检查退出码，并从 stdout 解析这唯一的 JSON 对象即可。
+
+## 网络与配置
+
+各网络的默认节点端点以及其他默认值，位于 `java/src/main/resources/config.conf`（HOCON 格式）。
+`--network` 标志在 `main`、`nile`（测试网）、`shasta`（测试网）和 `custom` 之间选择。对于
+`custom`，用 `--grpc-endpoint host:port` 提供端点。
+
+在 REPL 中，用 `SwitchNetwork` 切换网络，用 `CurrentNetwork` 查看当前网络。
+
+## 命令参考
+
+命令按领域分组：
+
+- [钱包管理](wallet-management.md) —— 创建/导入/导出钱包、登录、备份、锁定、活动钱包、别名。
+- [账户](accounts.md) —— 链上账户的创建与更新、余额、权限。
+- [质押与资源](staking.md) —— 冻结/解冻（v1 与 v2）、资源代理、奖励。
+- [交易](transactions.md) —— 转账 TRX/资产/USDT、多签签名、广播。
+- [智能合约](smart-contracts.md) —— 部署、触发、常量调用、能量预估。
+- [TRC-10 资产](trc10.md) —— 发行、更新、参与、转账以及查询 TRC-10 代币。
+- [治理](governance.md) —— 见证人、投票、提案、佣金、奖励提取。
+- [GasFree](gasfree.md) —— 免 gas（代付）的 USDT 转账。
+- [查询](query.md) —— 区块、交易、链参数、价格、节点及工具类命令。

--- a/docs/clients/wallet-cli/query.md
+++ b/docs/clients/wallet-cli/query.md
@@ -19,7 +19,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile current-network
+    java -jar java/build/libs/wallet-cli.jar --network nile current-network
     ```
 
 === "交互模式"
@@ -35,7 +35,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-chain-parameters
+    java -jar java/build/libs/wallet-cli.jar --network nile get-chain-parameters
     ```
 
 === "交互模式"
@@ -51,7 +51,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-next-maintenance-time
+    java -jar java/build/libs/wallet-cli.jar --network nile get-next-maintenance-time
     ```
 
 === "交互模式"
@@ -67,7 +67,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-bandwidth-prices
+    java -jar java/build/libs/wallet-cli.jar --network nile get-bandwidth-prices
     ```
 
 === "交互模式"
@@ -83,7 +83,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-energy-prices
+    java -jar java/build/libs/wallet-cli.jar --network nile get-energy-prices
     ```
 
 === "交互模式"
@@ -99,7 +99,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-memo-fee
+    java -jar java/build/libs/wallet-cli.jar --network nile get-memo-fee
     ```
 
 === "交互模式"
@@ -117,7 +117,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-block --number 1000000
+    java -jar java/build/libs/wallet-cli.jar --network nile get-block --number 1000000
     ```
 
     - `--number`（可选）—— 区块编号；默认为最新区块。
@@ -135,7 +135,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-block-by-id --id 00000000000f4240...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-block-by-id --id 00000000000f4240...
     ```
 
     - `--id`（必填）—— 区块 ID（哈希）。
@@ -153,7 +153,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-block-by-id-or-num --value 1000000
+    java -jar java/build/libs/wallet-cli.jar --network nile get-block-by-id-or-num --value 1000000
     ```
 
     - `--value`（必填）—— 区块编号或区块 ID。
@@ -172,7 +172,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-block-by-latest-num --count 5
+    java -jar java/build/libs/wallet-cli.jar --network nile get-block-by-latest-num --count 5
     ```
 
     - `--count`（必填）—— 要返回的最近区块数量。
@@ -190,7 +190,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-block-by-limit-next \
+    java -jar java/build/libs/wallet-cli.jar --network nile get-block-by-limit-next \
       --start 1000000 --end 1000005
     ```
 
@@ -207,7 +207,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile \
+    java -jar java/build/libs/wallet-cli.jar --network nile \
       get-transaction-count-by-block-num --number 1000000
     ```
 
@@ -228,7 +228,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-transaction-by-id --id <txid>
+    java -jar java/build/libs/wallet-cli.jar --network nile get-transaction-by-id --id <txid>
     ```
 
     - `--id`（必填）—— 交易 ID（哈希）。
@@ -246,7 +246,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-transaction-info-by-id --id <txid>
+    java -jar java/build/libs/wallet-cli.jar --network nile get-transaction-info-by-id --id <txid>
     ```
 
     - `--id`（必填）。
@@ -276,7 +276,7 @@ GetTransactionInfoByBlockNum number
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile list-nodes
+    java -jar java/build/libs/wallet-cli.jar --network nile list-nodes
     ```
 
 === "交互模式"
@@ -294,7 +294,7 @@ GetTransactionInfoByBlockNum number
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-usdt-balance --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-usdt-balance --address TXyz...
     ```
 
     - `--address`（可选）—— 默认为当前钱包的地址。

--- a/docs/clients/wallet-cli/smart-contracts.md
+++ b/docs/clients/wallet-cli/smart-contracts.md
@@ -21,7 +21,7 @@ REPL 的构建交易命令用可选的首参 `[OwnerAddress]` 支持多签；标
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile deploy-contract \
+    java -jar java/build/libs/wallet-cli.jar --network nile deploy-contract \
       --name MyToken \
       --abi '[{"inputs":[],"stateMutability":"nonpayable","type":"constructor"}, ...]' \
       --bytecode 608060405234801561001057600080fd5b50... \
@@ -53,7 +53,7 @@ REPL 的构建交易命令用可选的首参 `[OwnerAddress]` 支持多签；标
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile trigger-contract \
+    java -jar java/build/libs/wallet-cli.jar --network nile trigger-contract \
       --contract TContract... \
       --method "transfer(address,uint256)" \
       --params "TRecipient...,1000000" \
@@ -83,7 +83,7 @@ REPL 的构建交易命令用可选的首参 `[OwnerAddress]` 支持多签；标
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile trigger-constant-contract \
+    java -jar java/build/libs/wallet-cli.jar --network nile trigger-constant-contract \
       --contract TContract... \
       --method "balanceOf(address)" \
       --params "TAccount..."
@@ -107,7 +107,7 @@ REPL 的构建交易命令用可选的首参 `[OwnerAddress]` 支持多签；标
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile estimate-energy \
+    java -jar java/build/libs/wallet-cli.jar --network nile estimate-energy \
       --contract TContract... \
       --method "transfer(address,uint256)" \
       --params "TRecipient...,1000000"
@@ -142,7 +142,7 @@ Create2 address code salt
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-setting \
+    java -jar java/build/libs/wallet-cli.jar --network nile update-setting \
       --contract TContract... --consume-user-resource-percent 50
     ```
 
@@ -160,7 +160,7 @@ Create2 address code salt
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-energy-limit \
+    java -jar java/build/libs/wallet-cli.jar --network nile update-energy-limit \
       --contract TContract... --origin-energy-limit 10000000
     ```
 
@@ -180,7 +180,7 @@ Create2 address code salt
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile clear-contract-abi --contract TContract...
+    java -jar java/build/libs/wallet-cli.jar --network nile clear-contract-abi --contract TContract...
     ```
 
     - `--contract`（必填）。`--owner`、`--multi`（可选）。
@@ -200,7 +200,7 @@ Create2 address code salt
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-contract --address TContract...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-contract --address TContract...
     ```
 
     - `--address`（必填）。
@@ -218,7 +218,7 @@ Create2 address code salt
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-contract-info --address TContract...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-contract-info --address TContract...
     ```
 
     - `--address`（必填）。

--- a/docs/clients/wallet-cli/staking.md
+++ b/docs/clients/wallet-cli/staking.md
@@ -17,7 +17,7 @@ TRON 账户质押（冻结）TRX 以获取**带宽**和**能量**，并获得投
 码 `2`（TRON_POWER）对 freeze/unfreeze 命令受网络开关限制：
 `FreezeBalance`/`UnfreezeBalance`（Stake 1.0）、`FreezeBalanceV2`/`UnfreezeBalanceV2`（Stake 2.0）
 以及对应的标准 CLI 命令，只有在链参数 `getAllowNewResourceModel` 启用时才接受它。如果无法获取该链参数，
-4.9.7 客户端会 fail-open，让节点在广播时进行最终校验。代理命令（两种模式）始终只接受 `0` 或 `1`；
+客户端会 fail-open，让节点在广播时进行最终校验。代理命令（两种模式）始终只接受 `0` 或 `1`；
 TRON_POWER 不可代理。
 
 金额以 **SUN** 为单位（1 TRX = 1,000,000 SUN）。
@@ -36,7 +36,7 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile freeze-balance \
+    java -jar java/build/libs/wallet-cli.jar --network nile freeze-balance \
       --amount 1000000 --duration 3 --resource 1
     ```
 
@@ -59,7 +59,7 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile unfreeze-balance --resource 1
+    java -jar java/build/libs/wallet-cli.jar --network nile unfreeze-balance --resource 1
     ```
 
     - `--resource`（可选，`0`/`1`/`2`，默认 `0`）。`2` 是 TRON_POWER，仅在
@@ -82,7 +82,7 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile freeze-balance-v2 \
+    java -jar java/build/libs/wallet-cli.jar --network nile freeze-balance-v2 \
       --amount 1000000 --resource 1
     ```
 
@@ -104,7 +104,7 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile unfreeze-balance-v2 \
+    java -jar java/build/libs/wallet-cli.jar --network nile unfreeze-balance-v2 \
       --amount 1000000 --resource 1
     ```
 
@@ -126,7 +126,7 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile withdraw-expire-unfreeze
+    java -jar java/build/libs/wallet-cli.jar --network nile withdraw-expire-unfreeze
     ```
 
     - `--owner`、`--multi`（可选）。
@@ -144,7 +144,7 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile cancel-all-unfreeze-v2
+    java -jar java/build/libs/wallet-cli.jar --network nile cancel-all-unfreeze-v2
     ```
 
     - `--owner`、`--multi`（可选）。
@@ -164,7 +164,7 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile delegate-resource \
+    java -jar java/build/libs/wallet-cli.jar --network nile delegate-resource \
       --amount 1000000 --resource 1 --receiver TXyz... --lock --lock-period 86400
     ```
 
@@ -187,7 +187,7 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile undelegate-resource \
+    java -jar java/build/libs/wallet-cli.jar --network nile undelegate-resource \
       --amount 1000000 --resource 1 --receiver TXyz...
     ```
 
@@ -207,7 +207,7 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-account-net --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-account-net --address TXyz...
     ```
 
     - `--address`（必填）。
@@ -223,7 +223,7 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-account-resource --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-account-resource --address TXyz...
     ```
 
     - `--address`（必填）。
@@ -239,9 +239,9 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-delegated-resource \
+    java -jar java/build/libs/wallet-cli.jar --network nile get-delegated-resource \
       --from TFrom... --to TTo...
-    java -jar build/libs/wallet-cli.jar --network nile get-delegated-resource-v2 \
+    java -jar java/build/libs/wallet-cli.jar --network nile get-delegated-resource-v2 \
       --from TFrom... --to TTo...
     ```
 
@@ -259,9 +259,9 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile \
+    java -jar java/build/libs/wallet-cli.jar --network nile \
       get-delegated-resource-account-index --address TXyz...
-    java -jar build/libs/wallet-cli.jar --network nile \
+    java -jar java/build/libs/wallet-cli.jar --network nile \
       get-delegated-resource-account-index-v2 --address TXyz...
     ```
 
@@ -279,7 +279,7 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-can-delegated-max-size \
+    java -jar java/build/libs/wallet-cli.jar --network nile get-can-delegated-max-size \
       --owner TXyz... --type 1
     ```
 
@@ -298,7 +298,7 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-available-unfreeze-count --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-available-unfreeze-count --address TXyz...
     ```
 
     - `--address`（必填）。
@@ -314,7 +314,7 @@ TRON_POWER 不可代理。
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-can-withdraw-unfreeze-amount \
+    java -jar java/build/libs/wallet-cli.jar --network nile get-can-withdraw-unfreeze-amount \
       --address TXyz... --timestamp 1700000000000
     ```
 

--- a/docs/clients/wallet-cli/transactions.md
+++ b/docs/clients/wallet-cli/transactions.md
@@ -12,7 +12,7 @@ REPL 用可选的首参 `[OwnerAddress]` 支持多签；标准 CLI 用 `--owner`
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile send-coin \
+    java -jar java/build/libs/wallet-cli.jar --network nile send-coin \
       --to TXyz... --amount 1000000
     ```
 
@@ -31,7 +31,7 @@ REPL 用可选的首参 `[OwnerAddress]` 支持多签；标准 CLI 用 `--owner`
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile transfer-asset \
+    java -jar java/build/libs/wallet-cli.jar --network nile transfer-asset \
       --to TXyz... --asset 1000001 --amount 100
     ```
 
@@ -51,7 +51,7 @@ REPL 用可选的首参 `[OwnerAddress]` 支持多签；标准 CLI 用 `--owner`
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile transfer-usdt \
+    java -jar java/build/libs/wallet-cli.jar --network nile transfer-usdt \
       --to TXyz... --amount 1000000
     ```
 
@@ -101,7 +101,7 @@ TronlinkMultiSign
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile broadcast-transaction \
+    java -jar java/build/libs/wallet-cli.jar --network nile broadcast-transaction \
       --transaction 0a83010a02...
     ```
 

--- a/docs/clients/wallet-cli/trc10.md
+++ b/docs/clients/wallet-cli/trc10.md
@@ -13,7 +13,7 @@ REPL 的构建交易命令用可选的首参 `[OwnerAddress]` 支持多签；标
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile asset-issue \
+    java -jar java/build/libs/wallet-cli.jar --network nile asset-issue \
       --name MyToken --abbr MTK --total-supply 1000000000 \
       --trx-num 1 --ico-num 100 --precision 6 \
       --start-time 1700000000000 --end-time 1701000000000 \
@@ -43,7 +43,7 @@ REPL 的构建交易命令用可选的首参 `[OwnerAddress]` 支持多签；标
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile update-asset \
+    java -jar java/build/libs/wallet-cli.jar --network nile update-asset \
       --description "Updated" --url https://example.com \
       --new-limit 0 --new-public-limit 0
     ```
@@ -64,7 +64,7 @@ REPL 的构建交易命令用可选的首参 `[OwnerAddress]` 支持多签；标
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile participate-asset-issue \
+    java -jar java/build/libs/wallet-cli.jar --network nile participate-asset-issue \
       --to TIssuer... --asset 1000001 --amount 1000000
     ```
 
@@ -88,7 +88,7 @@ TRC-10 转账使用 `transfer-asset` / `TransferAsset`。见
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile unfreeze-asset
+    java -jar java/build/libs/wallet-cli.jar --network nile unfreeze-asset
     ```
 
     - `--owner`、`--multi`（可选）。
@@ -106,7 +106,7 @@ TRC-10 转账使用 `transfer-asset` / `TransferAsset`。见
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-asset-issue-by-account --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar --network nile get-asset-issue-by-account --address TXyz...
     ```
 
     - `--address`（必填）。
@@ -122,7 +122,7 @@ TRC-10 转账使用 `transfer-asset` / `TransferAsset`。见
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-asset-issue-by-id --id 1000001
+    java -jar java/build/libs/wallet-cli.jar --network nile get-asset-issue-by-id --id 1000001
     ```
 
     - `--id`（必填）。
@@ -138,7 +138,7 @@ TRC-10 转账使用 `transfer-asset` / `TransferAsset`。见
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-asset-issue-by-name --name MyToken
+    java -jar java/build/libs/wallet-cli.jar --network nile get-asset-issue-by-name --name MyToken
     ```
 
     - `--name`（必填）。
@@ -156,7 +156,7 @@ TRC-10 转账使用 `transfer-asset` / `TransferAsset`。见
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile get-asset-issue-list-by-name --name MyToken
+    java -jar java/build/libs/wallet-cli.jar --network nile get-asset-issue-list-by-name --name MyToken
     ```
 
     - `--name`（必填）。
@@ -172,7 +172,7 @@ TRC-10 转账使用 `transfer-asset` / `TransferAsset`。见
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile list-asset-issue
+    java -jar java/build/libs/wallet-cli.jar --network nile list-asset-issue
     ```
 
 === "交互模式"
@@ -186,7 +186,7 @@ TRC-10 转账使用 `transfer-asset` / `TransferAsset`。见
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile list-asset-issue-paginated \
+    java -jar java/build/libs/wallet-cli.jar --network nile list-asset-issue-paginated \
       --offset 0 --limit 20
     ```
 

--- a/docs/clients/wallet-cli/typescript-cli-signing.md
+++ b/docs/clients/wallet-cli/typescript-cli-signing.md
@@ -1,0 +1,128 @@
+# TypeScript CLI 签名与安全
+
+TypeScript CLI 支持软件 keystore、Ledger 账户和 watch-only 账户。软件私钥始终在本地加密保存，
+Ledger 私钥绝不会离开设备，watch-only 账户可以查询状态，但不能签名。
+
+## 签名现有交易 {#sign-an-existing-transaction}
+
+`tx sign` 可以签名在 wallet-cli 之外构建的 TRON 交易，但不会广播：
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli tx sign --transaction "$TX_JSON" --password-stdin --output json
+```
+
+对于软件账户，签名可以离线完成，`--network` 为可选项。该命令是一个纯签名器：它不会判断签名者
+是否拥有该交易、合约调用是否符合预期，也不会判断应转移多少价值。调用方仍需负责策略检查。
+
+### 交易完整性
+
+TRON 交易通过三个相互关联的字段表示其内容：
+
+| 字段 | 用途 |
+|------|------|
+| `raw_data` | 供用户和应用读取的交易内容。 |
+| `raw_data_hex` | 节点实际执行的字节。 |
+| `txID` | 签名覆盖的哈希。 |
+
+签名前，wallet-cli 要求 `txID` 等于 `raw_data_hex` 的 SHA-256 哈希。它还会解码交易的外层封装，
+并要求 `raw_data` 声明的合约类型与 `raw_data_hex` 中编码的类型一致。对于可以重新编码的合约类型，
+它还要求 `raw_data` 的字段级内容重新编码后得到相同字节。任何不一致都会返回 `tx_integrity`，且不会
+生成签名。
+
+底层库无法重新编码 `MarketSellAssetContract`、`MarketCancelOrderContract` 和
+`ShieldedTransferContract`。wallet-cli 仍会检查这类交易的哈希和合约类型，但无法将其 `raw_data`
+字段值与 `raw_data_hex` 对照验证；调用方必须把显示的这些字段值视为未经验证的数据。
+
+### 多签交易
+
+如果输入已经包含 `signature` 数组，`tx sign` 会追加新签名，而不是替换已有签名。因此，同一笔部分
+签名的交易可以依次传递给多个授权签名者，直到达到权限阈值。
+
+提取已签名的载荷，稍后再广播：
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli tx sign --transaction "$TX_JSON" --password-stdin --output json |
+  jq -c '.data.signed' > signed.json
+
+wallet-cli tx broadcast --network tron:nile --tx-stdin < signed.json
+```
+
+文本输出会打印完整签名，而不是缩写的交易标识符。
+
+## 签名类型化数据
+
+`typed-data sign` 用于签名 EIP-712/TIP-712 结构化数据，并返回签名者地址、推断或声明的主类型、
+摘要和签名：
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli typed-data sign \
+    --typed-data "$TYPED_DATA_JSON" \
+    --password-stdin \
+    --output json
+```
+
+载荷采用常见的 `domain`、`types`、`primaryType` 和 `message` 结构。CLI 会：
+
+- 忽略 `types` 中的 `EIP712Domain`；
+- 接受 `value` 作为 `message` 的别名；
+- 在 `address` 字段中接受 TRON Base58 地址；
+- 在省略 `primaryType` 时进行推断，并报告最终解析出的类型；
+- 拒绝不是消息根类型的已声明 `primaryType`。
+
+`domain.chainId` 会严格按输入值参与签名，不会与 `--network` 比较。签名前请检查 domain 和 message。
+
+## Ledger 行为
+
+`tx sign` 和 `typed-data sign` 均支持 Ledger 账户。交易完整性检查同样会在软件签名和 Ledger
+签名之前执行。
+
+类型化数据签名使用 TRON 应用的哈希签名能力。请在设备上启用
+**Settings > Sign by Hash > Allowed**，否则 CLI 会返回 `ledger_setting_required`。如果 TRON
+应用版本不支持该指令，则返回 `ledger_unsupported`。
+
+交易数据或自定义合约签名等其他 Ledger 应用设置，也会以可采取操作的
+`ledger_setting_required` 错误报告，而不是返回含义不清的 APDU 错误。设备超时或取消操作后会关闭
+传输连接，使后续尝试可以正常重新连接。
+
+Ledger 屏幕无法显示类型化数据的全部字段，可能只显示哈希。批准操作前，请在主机上核对载荷。
+
+## Secret 输入策略
+
+Secret 绝不会通过命令行参数或环境配置接收。
+
+支持的 stdin 通道如下：
+
+| 标志 | 输入 |
+|------|------|
+| `--password-stdin` | 用于解锁软件 keystore 的 master password。 |
+| `--tx-stdin` | `tx broadcast` 消费的已签名交易 JSON。 |
+| `--message-stdin` | `message sign` 消费的消息。 |
+
+单次调用中只能有一个 `*-stdin` 标志消费 stdin。
+
+以下高敏感度的初始化操作只能交互执行，并要求从真实 TTY 隐藏输入：
+
+- `import mnemonic`
+- `import private-key`
+- `change-password`
+
+它们不接受 `--mnemonic-stdin`、`--private-key-stdin` 或 `--password-stdin`。没有 TTY 时，
+命令会返回 `tty_required`。
+
+## 失败行为
+
+- watch-only 账户会在签名或写操作开始前返回 `watch_only_no_signer`。
+- 无效的全局选项值会返回 `invalid_value`，而不是退回默认值。
+- Ledger 设置和版本问题分别使用 `ledger_setting_required` 和 `ledger_unsupported`。
+- 交易的多种表示不一致时返回 `tx_integrity`。
+- 用户或设备拒绝签名时返回 `signing_rejected`。
+
+JSON 模式会在单个 `wallet-cli.result.v1` 信封中返回这些错误码；执行失败使用退出码 1，无效用法
+使用退出码 2。
+
+完整的字段级命令参考，请参见
+[`tx sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/sign.md) 和
+[`typed-data sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/typed-data/sign.md)。

--- a/docs/clients/wallet-cli/typescript-cli.md
+++ b/docs/clients/wallet-cli/typescript-cli.md
@@ -87,10 +87,16 @@ wallet-cli change-password
 `import mnemonic`、`import private-key` 和 `change-password` 只能交互执行。它们要求使用真实终端，
 并通过隐藏提示读取 secret，不提供非交互式 stdin 替代方式。
 
+以非交互方式使用 `derive`、`backup` 和 `tx sign` 等命令时，通过 `--password-stdin` 传入 master
+password。使用 Ledger 账户签名时，不要通过管道传入密码，也不要传入 `--password-stdin`。下方
+`derive` 示例展示了完整的非交互式写法。为了保持后续示例简洁，其中可能省略密码输入管道和
+`--password-stdin`。
+
 派生 HD 子账户时，需要传入 `wallet-cli list` 显示的 HD seed id。
 
 ```bash
-wallet-cli derive --seed-id wlt_ab12cd34 --label operations
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli derive --seed-id wlt_ab12cd34 --label operations --password-stdin
 ```
 
 删除根 HD 钱包会级联删除从该根派生出的账户，并清理孤立标签。在非交互式 shell 中需要传入 `--yes`；
@@ -284,13 +290,3 @@ wallet-cli tx send --json-schema
 
 `--timeout 0` 或不受支持的 `--output` 值等无效全局选项会返回 `invalid_value`，而不是静默退回
 默认值。
-
-非交互式鉴权时，只能通过 `--password-stdin` 管道传入 master password：
-
-```bash
-printf '%s\n' "$WALLET_PASSWORD" | wallet-cli message sign --message 'hello' --password-stdin --output json
-wallet-cli tx broadcast --tx-stdin < signed.json
-```
-
-密码示例假设 shell 变量通过安全方式注入且没有 export。每次调用只能有一个 `*-stdin` 标志消费
-stdin。`import mnemonic`、`import private-key` 和 `change-password` 必须在 TTY 中交互执行。

--- a/docs/clients/wallet-cli/typescript-cli.md
+++ b/docs/clients/wallet-cli/typescript-cli.md
@@ -5,7 +5,7 @@
 显示的是 npm 包版本。它与本节其他页面介绍的 Java JAR 是两套命令面：Java CLI 使用 `send-coin`
 这类命令，而 TypeScript CLI 使用 `tx send` 这类分组命令。
 
-当前 TypeScript CLI 支持 TRON 主网、Nile 和 Shasta。本版本尚不支持 EVM 链。
+当前 TypeScript CLI 支持 TRON 主网、Nile 和 Shasta，尚不支持 EVM 链。
 
 ## 安装
 
@@ -48,11 +48,17 @@ wallet-cli account balance --network tron:nile
 | `--timeout` | 每次 RPC/设备调用的超时时间，单位为毫秒。 |
 | `--verbose`, `-v` | 输出更多诊断信息。 |
 | `--wait` | 广播后轮询，直到交易 confirmed 或 failed。 |
-| `--wait-timeout` | `--wait` 轮询的上限，单位为毫秒。 |
+| `--wait-timeout` | `--wait` 轮询的上限，单位为毫秒；默认使用 `config.waitTimeoutMs`（内置值为 60000）。 |
 | `--password-stdin` | 从 stdin 读取 master password。 |
 
-命令级 stdin 标志包括 `--mnemonic-stdin`、`--private-key-stdin`、`--tx-stdin` 和
-`--message-stdin`。单次调用中只能有一个 `*-stdin` 标志消费 stdin。
+命令级 stdin 标志为 `--tx-stdin` 和 `--message-stdin`。它们与全局的 `--password-stdin`
+合计只能有一个 `*-stdin` 标志在单次调用中消费 stdin。
+
+可以使用 `wallet-cli config` 持久化默认值。例如：
+
+```bash
+wallet-cli config waitTimeoutMs 90000
+```
 
 ## 钱包和账户
 
@@ -75,9 +81,13 @@ wallet-cli use main
 wallet-cli current
 wallet-cli rename main --label primary
 wallet-cli backup primary --out ~/primary-backup.json
+wallet-cli change-password
 ```
 
-4.9.7 中，HD 子账户派生需要显式传入 seed id；该 seed id 可通过 `wallet-cli list` 查看。
+`import mnemonic`、`import private-key` 和 `change-password` 只能交互执行。它们要求使用真实终端，
+并通过隐藏提示读取 secret，不提供非交互式 stdin 替代方式。
+
+派生 HD 子账户时，需要传入 `wallet-cli list` 显示的 HD seed id。
 
 ```bash
 wallet-cli derive --seed-id wlt_ab12cd34 --label operations
@@ -102,13 +112,16 @@ wallet-cli tx send --to T... --contract TR7... --amount 5
 wallet-cli tx send --to T... --asset-id 1002000 --raw-amount 1000000
 ```
 
-改变链上状态的命令支持三种执行模式：
+交易构建命令支持三种执行模式：
 
 | 模式 | 行为 |
 |------|----------|
 | 默认 | 构建、签名并广播。 |
 | `--dry-run` | 构建并估算，不签名、不广播。 |
 | `--sign-only` | 签名并输出交易，但不广播。 |
+
+默认模式在交易提交后返回。添加 `--wait` 后，CLI 会轮询 FullNode 的未确认视图，直到交易确认或失败。
+如果达到轮询时间上限，CLI 会返回已提交的回执，而不会错误地表示广播失败。
 
 稍后广播已签名交易：
 
@@ -123,7 +136,17 @@ wallet-cli tx status --txid <TXID>
 wallet-cli tx info --txid <TXID> --output json
 ```
 
-## 查询和签名
+CLI 还提供一个纯粹、可离线使用的签名器，用于签名在其他位置构建的交易：
+
+```bash
+wallet-cli tx sign --transaction "$TX_JSON"
+```
+
+它始终验证 `txID` 是否为 `raw_data_hex` 的哈希，并验证声明的合约类型是否与编码后的交易一致。
+对于可以重新编码的合约类型，它还会验证 `raw_data` 的字段级内容。在多签工作流中，它会向已有的
+签名数组追加签名。详见[签名与安全](typescript-cli-signing.md#sign-an-existing-transaction)。
+
+## 查询
 
 与钱包绑定的账户查询默认使用 active account，也可以通过 `--account` 指定账户。
 
@@ -134,8 +157,17 @@ wallet-cli account portfolio
 wallet-cli networks
 wallet-cli block
 wallet-cli block 12345
-wallet-cli message sign --message 'hello'
+wallet-cli chain params
+wallet-cli chain prices
+wallet-cli chain node
+wallet-cli stake info
+wallet-cli stake delegated --direction out
+wallet-cli vote status
+wallet-cli reward balance
 ```
+
+有关字段级命令语义和更多示例，请参见
+[上游 TypeScript 命令参考](https://github.com/tronprotocol/wallet-cli/tree/master/ts/docs/commands)。
 
 ## Token 和合约
 
@@ -175,6 +207,8 @@ wallet-cli contract deploy \
 
 在 JSON 输出中，TypeScript CLI 的合约部署成功后，部署回执数据会包含部署出的 `contractAddress`。
 
+当地址上没有已部署的合约时，`contract info` 会返回 not-found 错误，而不是返回空合约。
+
 合约部署需要软件账户。Ledger TRON app 无法签名 `CreateSmartContract`，因此 Ledger 支持的
 账户不能使用 `wallet-cli contract deploy`。
 
@@ -189,9 +223,44 @@ wallet-cli stake undelegate --amount-sun 1000000 --receiver T... --resource ener
 wallet-cli stake unfreeze --amount-sun 1000000 --resource energy --dry-run
 wallet-cli stake cancel-unfreeze --dry-run
 wallet-cli stake withdraw --dry-run
+wallet-cli stake info
+wallet-cli stake delegated --direction out
 ```
 
 `stake cancel-unfreeze` 需要软件账户；Ledger TRON app 无法签名 `CancelAllUnfreezeV2Contract`。
+
+`stake withdraw` 会在构建交易前检查可提取金额；如果没有已到期的解冻 TRX，则返回
+`nothing_to_withdraw`。
+
+## 投票和奖励
+
+TypeScript CLI 可以查看超级代表、替换账户的投票分配、查询可领取奖励并提取奖励：
+
+```bash
+wallet-cli vote list
+wallet-cli vote status
+wallet-cli vote cast --for TZ4...=600 --for TT5...=400
+wallet-cli reward balance
+wallet-cli reward withdraw
+```
+
+`vote cast` 会替换现有的完整投票分配，未列出的 SR 会被设为零票。`vote cast` 和
+`reward withdraw` 都会创建交易，因此需要签名账户。当可领取余额为空时，`reward withdraw` 返回
+`no_reward`；未满 24 小时的提取间隔时，则返回 `withdraw_too_frequent`。
+
+## 签名
+
+除 `message sign` 外，CLI 还提供 `tx sign` 和 EIP-712/TIP-712 `typed-data sign`。软件账户和
+Ledger 账户均受支持；watch-only 账户会在写入或签名操作开始前失败。
+
+```bash
+wallet-cli message sign --message 'hello'
+wallet-cli tx sign --transaction "$TX_JSON"
+wallet-cli typed-data sign --typed-data "$TYPED_DATA_JSON"
+```
+
+有关交易完整性检查、多签行为、Ledger 设置和 secret 输入规则，请参见
+[签名与安全](typescript-cli-signing.md)。
 
 ## 自动化
 
@@ -210,14 +279,18 @@ wallet-cli --json-schema
 wallet-cli tx send --json-schema
 ```
 
-输入 secret 时，应通过 stdin 管道传入，避免放在 argv 或导出的环境变量中：
+规范命令 ID 不带 `tron.` 前缀：例如命令 ID 是 `tx.send`，而不是 `tron.tx.send`。网络 family 则通过
+`chain.family` 单独提供。
+
+`--timeout 0` 或不受支持的 `--output` 值等无效全局选项会返回 `invalid_value`，而不是静默退回
+默认值。
+
+非交互式鉴权时，只能通过 `--password-stdin` 管道传入 master password：
 
 ```bash
 printf '%s\n' "$WALLET_PASSWORD" | wallet-cli message sign --message 'hello' --password-stdin --output json
-printf '%s\n' "$MNEMONIC" | wallet-cli import mnemonic --label main --mnemonic-stdin
-printf '%s\n' "$PRIVATE_KEY" | wallet-cli import private-key --label hot --private-key-stdin
+wallet-cli tx broadcast --tx-stdin < signed.json
 ```
 
-这些示例假设 shell 变量通过安全方式注入且没有 export。每次调用只能有一个 `*-stdin` 标志消费 stdin。
-`import mnemonic` 和 `import private-key` 等命令同时需要 master password 与 mnemonic/private key；
-如果通过管道传入其中一个 secret，另一个必须在 TTY 中交互输入。它们不能在单 stdin 调用中完全非交互式完成。
+密码示例假设 shell 变量通过安全方式注入且没有 export。每次调用只能有一个 `*-stdin` 标志消费
+stdin。`import mnemonic`、`import private-key` 和 `change-password` 必须在 TTY 中交互执行。

--- a/docs/clients/wallet-cli/wallet-management.md
+++ b/docs/clients/wallet-cli/wallet-management.md
@@ -20,7 +20,7 @@
 
     ```bash
     export MASTER_PASSWORD='your-wallet-password'
-    java -jar build/libs/wallet-cli.jar --network nile register-wallet --name my-wallet --words 12
+    java -jar java/build/libs/wallet-cli.jar --network nile register-wallet --name my-wallet --words 12
     ```
 
     - `--name`（必填）—— 钱包名称。
@@ -42,7 +42,7 @@
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar --network nile generate-sub-account --index 1 --name sub-1
+    java -jar java/build/libs/wallet-cli.jar --network nile generate-sub-account --index 1 --name sub-1
     ```
 
     - `--index`（必填）—— 派生索引。
@@ -91,14 +91,14 @@ GenerateAddress [isECKey]
 
     ```bash
     # 列出钱包及其活动状态
-    java -jar build/libs/wallet-cli.jar list-wallet
+    java -jar java/build/libs/wallet-cli.jar list-wallet
 
     # 按地址或名称设置活动钱包
-    java -jar build/libs/wallet-cli.jar set-active-wallet --address TXyz...
-    java -jar build/libs/wallet-cli.jar set-active-wallet --name my-wallet
+    java -jar java/build/libs/wallet-cli.jar set-active-wallet --address TXyz...
+    java -jar java/build/libs/wallet-cli.jar set-active-wallet --name my-wallet
 
     # 显示当前活动钱包
-    java -jar build/libs/wallet-cli.jar get-active-wallet
+    java -jar java/build/libs/wallet-cli.jar get-active-wallet
     ```
 
     - `set-active-wallet` 接受 `--address` 或 `--name`（提供其一）。
@@ -148,7 +148,7 @@ ChangePassword
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar modify-wallet-name --name new-name
+    java -jar java/build/libs/wallet-cli.jar modify-wallet-name --name new-name
     ```
 
     - `--name`（必填）—— 新的钱包名称。需要鉴权。
@@ -166,7 +166,7 @@ ChangePassword
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar clear-wallet-keystore --force
+    java -jar java/build/libs/wallet-cli.jar clear-wallet-keystore --force
     ```
 
     - `--force` 在语法上是可选的，但在标准 CLI 模式下执行这一破坏性操作时必须提供 —— 不带它命令会
@@ -185,7 +185,7 @@ ChangePassword
 === "标准 CLI"
 
     ```bash
-    java -jar build/libs/wallet-cli.jar reset-wallet --confirm delete-all-wallets
+    java -jar java/build/libs/wallet-cli.jar reset-wallet --confirm delete-all-wallets
     ```
 
     - `--confirm` 必须传入确切的值 `delete-all-wallets` 才会执行重置。不带 `--confirm` 运行
@@ -230,21 +230,21 @@ Base58 地址。别名按网络隔离，来自两层：一组**内置**别名（
 
 ```bash
 # 添加账户别名
-java -jar build/libs/wallet-cli.jar --network nile alias-add \
+java -jar java/build/libs/wallet-cli.jar --network nile alias-add \
   --name treasury --type ACCOUNT --address TXyz... --note "team treasury"
 
 # 添加代币别名（带精度）
-java -jar build/libs/wallet-cli.jar --network nile alias-add \
+java -jar java/build/libs/wallet-cli.jar --network nile alias-add \
   --name usdt --type TOKEN --address TR7NHq... --decimals 6
 
 # 列出别名（可按类型过滤）
-java -jar build/libs/wallet-cli.jar --network nile alias-list --type ACCOUNT
+java -jar java/build/libs/wallet-cli.jar --network nile alias-list --type ACCOUNT
 
 # 把别名或地址解析为其规范形式
-java -jar build/libs/wallet-cli.jar --network nile alias-resolve --name treasury
+java -jar java/build/libs/wallet-cli.jar --network nile alias-resolve --name treasury
 
 # 删除用户别名
-java -jar build/libs/wallet-cli.jar --network nile alias-remove --name treasury
+java -jar java/build/libs/wallet-cli.jar --network nile alias-remove --name treasury
 ```
 
 选项说明：

--- a/docs/mechanism-algorithm/multi-signatures.md
+++ b/docs/mechanism-algorithm/multi-signatures.md
@@ -232,7 +232,7 @@ System.out.println(ByteArray.toHexString(operations));
 6. 最后一个用户签名后广播；
 7. 节点验证签名权重总和是否 ≥ `threshold`，若是则接受交易。
 
->示例代码参考：[wallet-cli 用例](https://github.com/tronprotocol/wallet-cli/blob/develop/src/main/java/org/tron/common/utils/TransactionUtils.java)
+>示例代码参考：[wallet-cli 用例](https://github.com/tronprotocol/wallet-cli/blob/develop/java/src/main/java/org/tron/common/utils/TransactionUtils.java)
 
 ## 辅助接口
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -276,17 +276,21 @@ nav:
         - 工具: contracts/tools.md
     - 客户端:
         - wallet-cli:
-            - clients/wallet-cli/index.md
-            - 钱包管理: clients/wallet-cli/wallet-management.md
-            - 账户: clients/wallet-cli/accounts.md
-            - 质押与资源: clients/wallet-cli/staking.md
-            - 交易: clients/wallet-cli/transactions.md
-            - 智能合约: clients/wallet-cli/smart-contracts.md
-            - TRC-10 资产: clients/wallet-cli/trc10.md
-            - 治理: clients/wallet-cli/governance.md
-            - GasFree: clients/wallet-cli/gasfree.md
-            - 查询: clients/wallet-cli/query.md
-            - TypeScript / npm CLI: clients/wallet-cli/typescript-cli.md
+            - 概览: clients/wallet-cli/index.md
+            - Java CLI:
+                - 概览: clients/wallet-cli/java-cli.md
+                - 钱包管理: clients/wallet-cli/wallet-management.md
+                - 账户: clients/wallet-cli/accounts.md
+                - 质押与资源: clients/wallet-cli/staking.md
+                - 交易: clients/wallet-cli/transactions.md
+                - 智能合约: clients/wallet-cli/smart-contracts.md
+                - TRC-10 资产: clients/wallet-cli/trc10.md
+                - 治理: clients/wallet-cli/governance.md
+                - GasFree: clients/wallet-cli/gasfree.md
+                - 查询: clients/wallet-cli/query.md
+            - TypeScript / npm CLI:
+                - 概览: clients/wallet-cli/typescript-cli.md
+                - 签名与安全: clients/wallet-cli/typescript-cli-signing.md
     - 版本发布:
         - 新版本部署手册: releases/upgrade-instruction.md
         - 一致性检验: releases/signature_verification.md


### PR DESCRIPTION
## Summary

- Translate and mirror the reorganized wallet-cli navigation with separate Java and TypeScript / npm CLI sections.
- Add translated Java CLI and TypeScript signing and security overviews.
- Update Java paths and document the current TypeScript CLI confirmation, signing, staking, voting, and reward behavior.

## Why

The Chinese documentation should remain aligned with the English wallet-cli documentation and the wallet-cli v4.10.0 repository layout and behavior.

## Impact

Chinese readers receive the same wallet-cli structure, command guidance, and security information as the English documentation.

## Validation

- `mkdocs build --strict`
- `git diff --check`
