### PR TITLE
align tvm documentation with java-tron v4.8.2

### DIFF
--- a/docs/api/http/smart-contract/estimateenergy.md
+++ b/docs/api/http/smart-contract/estimateenergy.md
@@ -59,6 +59,10 @@ curl --request POST \
 
 未开启 `vm.estimateEnergy=true` 时调用走 `ContractValidateException` 分支（见下文）：`result.code = CONTRACT_VALIDATE_ERROR`，`result.message` 为 `this node does not support estimate energy`。
 
+Energy 估算通过 constant call 路径执行，并受
+[`vm.constantCallTimeoutMs`](../../../using_javatron/configuration.md#tvm-and-constant-call-configuration)
+限制。
+
 ### 异常响应
 
 请求进入 servlet 后不会写出 `{"Error": ...}`。由 servlet 接管的异常会被 catch 后写入 `result.code`、`result.message`，HTTP 体仍是 `EstimateEnergyMessage`。
@@ -68,7 +72,7 @@ curl --request POST \
 | 触发条件 | `result.result` | `result.code` | `result.message` |
 |---|---|---|---|
 | 节点未开启 `vm.estimateEnergy` | false | `CONTRACT_VALIDATE_ERROR` | `this node does not support estimate energy` |
-| 节点关闭 constant-call 支持 | false | `CONTRACT_VALIDATE_ERROR` | `this node does not support constant, so estimate energy cannot work` |
+| 节点关闭 constant call 支持 | false | `CONTRACT_VALIDATE_ERROR` | `this node does not support constant, so estimate energy cannot work` |
 | `contract_address` 已设置但合约不存在 | false | `CONTRACT_VALIDATE_ERROR` | `Smart contract is not exist.` |
 | EVM exception / retry 耗尽 / 其他非校验异常 | false | `OTHER_ERROR` | `<exceptionClass> : <message>`（`"` → `'`） |
 

--- a/docs/api/http/smart-contract/triggerconstantcontract.md
+++ b/docs/api/http/smart-contract/triggerconstantcontract.md
@@ -93,7 +93,13 @@ curl --request POST \
 }
 ```
 
-> `txID` / `ref_block_*` / `expiration` / `timestamp` / `raw_data_hex` 等 ephemeral 字段语义同 [`/wallet/createtransaction`](../tx-build-and-broadcast/createtransaction.md)。常量调用本身不上链，`transaction` 字段仅作上下文。
+> `txID` / `ref_block_*` / `expiration` / `timestamp` / `raw_data_hex` 等 ephemeral 字段语义同 [`/wallet/createtransaction`](../tx-build-and-broadcast/createtransaction.md)。constant call 本身不上链，`transaction` 字段仅作上下文。
+
+> **执行超时：** 该接口使用节点的 constant call 执行时限。
+> `vm.constantCallTimeoutMs = 0` 时使用网络的
+> `MAX_CPU_TIME_OF_ONE_TX` 限制；正值则设置仅适用于 constant call 的执行时限，
+> 单位为毫秒。请参阅
+> [TVM 与 constant call 配置](../../../using_javatron/configuration.md#tvm-and-constant-call-configuration)。
 
 ### 异常响应
 
@@ -104,7 +110,7 @@ curl --request POST \
 | 触发条件 | `result.result` | `result.code` | `result.message` | 其他 |
 |---|---|---|---|---|
 | `contract_address` 已设置但合约不存在 | 缺省 (false) | `CONTRACT_VALIDATE_ERROR` | `Smart contract is not exist.` | — |
-| 节点关闭 constant-call 支持 | 缺省 (false) | `CONTRACT_VALIDATE_ERROR` | `this node does not support constant` | — |
+| 节点关闭 constant call 支持 | 缺省 (false) | `CONTRACT_VALIDATE_ERROR` | `this node does not support constant` | — |
 | EVM revert / `require` 失败 | true | 缺省（`SUCCESS`，不出现） | `REVERT opcode executed` | `transaction.ret[0].ret="FAILED"`；`constant_result[0]` 为 `Error(string)` 的 ABI 编码（合约带 reason 时） |
 | EVM 运行时错误（OOG、非法指令等，无 `result.getException()`） | true | 缺省（`SUCCESS`，不出现） | `result.getRuntimeError()` 原始字符串 | 同上 |
 | `result.getException() != null`（如 `OutOfTimeException`） | 缺省 (false) | `OTHER_ERROR` | `<exceptionClass> : <message>`（`"` → `'`） | — |

--- a/docs/api/http/smart-contract/triggersmartcontract.md
+++ b/docs/api/http/smart-contract/triggersmartcontract.md
@@ -52,7 +52,7 @@ curl --request POST \
 | `txid` | string(hex) | 交易哈希 |
 | `constant_result` | repeated bytes(hex) | 仅在被 ABI 识别为 `view` / `pure` 函数时填充（写交易通常无此字段） |
 | `result` | Return | 结果状态 |
-| `energy_used` | int64 | 仅在常量调用路径填充；普通写交易不返回 |
+| `energy_used` | int64 | 仅在 constant call 路径填充；普通写交易不返回 |
 | `energy_penalty` | int64 | 能量惩罚（如有） |
 
 响应示例（Nile 实抓）：
@@ -91,6 +91,11 @@ curl --request POST \
 > `txID` / `ref_block_*` / `expiration` / `timestamp` / `raw_data_hex` 等 ephemeral 字段语义同 [`/wallet/createtransaction`](../tx-build-and-broadcast/createtransaction.md)。写交易路径不会填充 `txid` / `constant_result` / `energy_used`；如需要预演结果改用 [`/wallet/triggerconstantcontract`](triggerconstantcontract.md)。
 
 > 仅做预演（不上链）请用 [`/wallet/triggerconstantcontract`](triggerconstantcontract.md)；仅估算能量请用 [`/wallet/estimateenergy`](estimateenergy.md)。
+
+> 当 ABI 将目标函数标记为 `view` 或 `pure` 时，该接口会被分派到
+> constant call 路径，因此受
+> [`vm.constantCallTimeoutMs`](../../../using_javatron/configuration.md#tvm-and-constant-call-configuration)
+> 限制。
 
 ### 异常响应
 

--- a/docs/api/json-rpc/smart-contract/eth_call.md
+++ b/docs/api/json-rpc/smart-contract/eth_call.md
@@ -54,6 +54,11 @@ curl -X POST https://nile.trongrid.io/jsonrpc \
 }
 ```
 
+`eth_call` 通过节点的 constant call 路径执行，并受
+[`vm.constantCallTimeoutMs`](../../../using_javatron/configuration.md#tvm-and-constant-call-configuration)
+限制。默认值 `0` 使用网络的 `MAX_CPU_TIME_OF_ONE_TX` 限制；正值则设置
+仅适用于 constant call 的执行时限，单位为毫秒。
+
 ### 异常响应
 
 | 触发条件 | 错误码 | message |

--- a/docs/api/json-rpc/smart-contract/eth_estimateGas.md
+++ b/docs/api/json-rpc/smart-contract/eth_estimateGas.md
@@ -38,8 +38,12 @@ energy 用量的 hex 编码：
 
 - 普通 TRX 转账（`TransferContract`）→ `0x0`
 - 合约调用 / 部署 → 视节点配置：
-    - `node.supportEstimateEnergy = true` 时返回 `EstimateEnergyMessage.energyRequired`
-    - 默认（false）→ 返回 `TransactionExtention.energyUsed`（一次 constant-call 的实际用量）
+    - `vm.estimateEnergy = true` 时返回 `EstimateEnergyMessage.energyRequired`
+    - 默认（false）→ 返回 `TransactionExtention.energyUsed`（一次 constant call 的实际用量）
+
+合约调用和部署的 Energy 估算使用 constant call 路径，并受
+[`vm.constantCallTimeoutMs`](../../../using_javatron/configuration.md#tvm-and-constant-call-configuration)
+限制。
 
 下例为上面 curl 调用 Nile testnet 抓回的真实响应（TRX 转账走 `TransferContract` 路径，直接返回 `0x0`，不进入 EVM）：
 

--- a/docs/contracts/contract.md
+++ b/docs/contracts/contract.md
@@ -103,6 +103,9 @@ Constant function 是指用 `view`/`pure` 修饰的函数。会在调用的节�
 
 **注意**：与通过 gRPC `deployContract` 创建合约不同，由 `CREATE` 指令创建的合约不会保存合约的 abi。
 
+当 `ALLOW_TVM_OSAKA` 激活时，`CREATE2` 达到最大调用深度会将零压入栈，
+而不会继续尝试创建合约。
+
 #### 内置功能与内置函数属性
 
 1. TVM 兼容 Solidity 语言的转账形式，包括：
@@ -113,7 +116,7 @@ Constant function 是指用 `view`/`pure` 修饰的函数。会在调用的节�
 
     **注意**：TRON 的智能合约与 TRON 的系统合约不同。在 SOLIDITY_059 升级（链参数 `ALLOW_TVM_SOLIDITY_059`，由委员会 [提案 #29](https://tronscan.io/#/proposal/29) 激活）之前，从智能合约向不存在的账户转账会失败；激活之后，TVM 会在转账时自动创建目标账户，与系统合约行为一致。
 
-2. 在合约内为超级节点投票以及提取投票奖励。由链参数 `ALLOW_TVM_VOTE` 启用，由委员会 [提案 #84](https://tronscan.io/#/proposal/84) 在主网激活。提供 `VOTEWITNESS` / `WITHDRAWREWARD` 操作码以及相关的只读预编译合约。
+2. 在合约内为超级节点投票以及提取投票奖励。由链参数 `ALLOW_TVM_VOTE` 启用，由委员会 [提案 #84](https://tronscan.io/#/proposal/84) 在主网激活。提供 `VOTEWITNESS` / `WITHDRAWREWARD` 操作码以及相关的只读预编译合约。执行时，TVM 会根据已激活的链参数选择 `VOTEWITNESS` 的 Energy 计算方式。当 `ALLOW_TVM_OSAKA` 已激活时，使用 `BigInteger` 处理动态数组的偏移、长度和内存边界，以防止 256 位回绕。否则，如果 `ALLOW_ENERGY_ADJUSTMENT` 已激活，则使用 Energy 调整计算方式；两个参数均未激活时，则使用未包含 Energy 调整和 Osaka 溢出保护的原始计算方式。
 
 3. TRC-10 token 操作：向目标地址发送 TRC-10、查询某地址的 TRC-10 余额。由链参数 `ALLOW_TVM_TRANSFER_TRC10` 启用，由委员会 [提案 #15](https://tronscan.io/#/proposal/15) 在主网激活。
 
@@ -183,6 +186,20 @@ function assignAddress() public view {
 #### 区块相关
 
 - `blockhash(uint blockNumber) returns (bytes32)`：指定区块的区块哈希——仅可用于最新的 256 个区块且不包括当前区块。**注意**：`block.blockhash(uint)` 形式在上游 Solidity 0.4.22 中被弃用，并在 0.5.0 中被移除；TRON 的 Solidity fork 自 `tv_0.4.24` 起继承了弃用，自 `tv_0.5.4` 起继承了移除——请改用顶层的 `blockhash(...)`
+
+    如需访问更早的区块哈希，`ALLOW_TVM_PRAGUE` 链参数（ID 95）会在
+    `0x0000F90827F1C53a10cb7A02335B175320002935` 地址部署
+    [TIP-2935](https://github.com/tronprotocol/tips/blob/master/tip-2935.md)
+    区块哈希历史合约。由于该历史合约的字节码使用了 `PUSH0`，因此必须先激活
+    `ALLOW_TVM_SHANGHAI`，才能激活此参数。
+
+    该合约使用包含 8191 个槽位的环形缓冲区存储父区块哈希。对于以 32 字节编码的
+    区块号 `K`，当 `K` 位于 `[block.number - 8191, block.number - 1]`
+    范围内时查询有效；查询未来区块或超出该窗口的区块会导致调用回滚。激活时不会
+    回填更早区块的哈希，因此该缓冲区会在参数生效后逐步填充。
+
+    该合约是对 `BLOCKHASH` 操作码的补充，并不会改变其行为。
+
 - `block.basefee` (uint)：返回链参数中的网络能量费（`getEnergyFee`）；与以太坊基于每个区块的 EIP-1559 base fee 不同，该值只在委员会提案修改时才会变化。自 London 升级（`ALLOW_TVM_LONDON`）起可用，由委员会 [提案 #72](https://tronscan.io/#/proposal/72) 在主网激活
 - `block.coinbase` (address)：产当前区块的超级节点地址
 - `block.difficulty` (uint)：当前区块难度，波场不推荐使用，设置恒为 0

--- a/docs/using_javatron/configuration.md
+++ b/docs/using_javatron/configuration.md
@@ -152,6 +152,37 @@ storage {
 
 不要将管理类接口或交易构造接口直接暴露给不受信任的网络。应通过主机或网络控制限制访问，并在需要时将公共服务置于配置适当的网关之后。有关各协议的具体行为，请参阅 [HTTP API](../api/http/index.md) 和 [JSON-RPC API](../api/json-rpc/index.md) 指南。
 
+## TVM 与 constant call 配置 { #tvm-and-constant-call-configuration }
+
+TVM 模拟和 Energy 估算行为通过 `vm` 配置：
+
+| 配置路径 | 默认值 | 用途 |
+|---|---:|---|
+| `vm.supportConstant` | `false` | 启用只读的 constant call。 |
+| `vm.maxEnergyLimitForConstant` | `100000000` | 单次 constant call 可用的最大 Energy。配置绑定期间，小于 3,000,000 的值会提高到该下限。 |
+| `vm.estimateEnergy` | `false` | 启用专用的 `estimateenergy` 实现。 |
+| `vm.estimateEnergyMaxRetry` | `3` | Energy 估算期间的最大重试次数；取值会被限制在 0–10 范围内。 |
+| `vm.constantCallTimeoutMs` | `0` | 通过 constant call 路径执行的调用可使用的执行时限，单位为毫秒。 |
+| `vm.vmTrace` | `false` | 启用 TVM trace 输出。 |
+
+`vm.constantCallTimeoutMs = 0` 保留原有行为，即 constant call 使用网络的
+`MAX_CPU_TIME_OF_ONE_TX` 限制。正值设置仅适用于 constant call 的执行时限，
+单位为毫秒。负值或因数值过大而无法安全转换为 VM 微秒级执行时限的值会导致
+配置加载失败。debug 模式和独立 SolidityNode 不会执行该时限检查；发送到
+FullNode `/walletsolidity` 接口的 constant call 仍受该时限限制。
+
+该配置适用于通过 HTTP、gRPC 和 JSON-RPC 执行的 constant call，包括
+[`/wallet/triggerconstantcontract`](../api/http/smart-contract/triggerconstantcontract.md)、
+ABI `view`/`pure` 函数被分派到 constant call 路径时的
+[`/wallet/triggersmartcontract`](../api/http/smart-contract/triggersmartcontract.md)、
+[`/wallet/estimateenergy`](../api/http/smart-contract/estimateenergy.md)、
+[`eth_call`](../api/json-rpc/smart-contract/eth_call.md) 和
+[`eth_estimateGas`](../api/json-rpc/smart-contract/eth_estimateGas.md)。
+
+对于生产节点，当复杂的只读调用需要更长执行时间时，可使用
+`vm.constantCallTimeoutMs`。修改这些 `vm` 配置需要重启进程；动态配置重载不会
+应用这些变更。
+
 ## 限流
 
 API 限制在 `rate.limiter` 下配置：

--- a/docs/using_javatron/private_network.md
+++ b/docs/using_javatron/private_network.md
@@ -126,10 +126,10 @@
 
        * **方式二：通过链上提案修改 (适用于运行中的网络)**
         
-        这是链上治理的标准方式，任何 超级代表（SR）、SR Partner、SR Candidate 都有权创建提案，但只有 SR 有权投票批准。
+        这是链上治理的标准方式。任何超级代表（SR）、超级代表合伙人（SR Partner）或超级代表候选人（SR Candidate）都可以创建提案或对提案表示赞成，但只有当前活跃 SR 的赞成才计入提案通过阈值。
 
          - 创建提案：SR 使用 [proposalcreate](../api/http/witness-and-governance/proposalcreate.md) API，通过参数序号指定要修改的参数及其新值（参数序号列表)。
-         - 批准提案：SR 使用 [proposalapprove](../api/http/witness-and-governance/proposalapprove.md) API 对提案进行投票（仅支持投赞成票，SR 不投票意味着不同意该提案）。
+         - 赞成提案：SR 使用 [proposalapprove](../api/http/witness-and-governance/proposalapprove.md) API 赞成提案或取消赞成。判断提案是否达到通过阈值时，只统计当前活跃 SR 的有效赞成；未赞成或已取消赞成不会增加赞成数量。
          - 相关接口：
               - 获取所有提案：[listproposals](../api/http/witness-and-governance/listproposals.md)
               - 根据 ID 获取提案：[getproposalbyid](../api/http/witness-and-governance/getproposalbyid.md)
@@ -172,6 +172,6 @@
       
       提案投票通过并在维护期结束后，新的网络参数将会生效。您可以通过 [listproposals](../api/http/witness-and-governance/listproposals.md) 或 [getchainparameters](../api/http/witness-and-governance/getchainparameters.md) 来验证变更。
   
-      需要注意的是，具有相互依赖关系的网络参数不能包含在同一个提案中，正确的方法是将它们分成不同的提案，并注意它们的顺序。
+      需要注意的是，具有相互依赖关系的网络参数不能包含在同一个提案中，正确的方法是将它们分成不同的提案，并注意它们的顺序。例如，应先激活 `ALLOW_TVM_SHANGHAI`，再发起启用 95 号参数（`ALLOW_TVM_PRAGUE`）的提案。
      
      


### PR DESCRIPTION
## Summary

- Align TVM contract documentation with java-tron v4.8.2 behavior, including CREATE2 depth handling and VOTEWITNESS Energy calculation selection.
- Document TIP-2935 block-hash history, the Prague/Shanghai activation dependency, and governance approval semantics.
- Document constant-call timeout configuration and the supported HTTP, gRPC, and JSON-RPC paths.
- Clarify the `MAX_CPU_TIME_OF_ONE_TX` deadline and correct the `eth_estimateGas` configuration key.

## Why

The documentation had drifted from current java-tron TVM and API behavior. These changes bring the documented behavior and configuration back in line with the source implementation.

## Validation

- Reviewed the changes against the java-tron source.
- Ran `mkdocs build --strict` successfully.
