### PR TITLE
align moniter documentation with java-tron v4.8.2

### DIFF
--- a/docs/using_javatron/configuration.md
+++ b/docs/using_javatron/configuration.md
@@ -177,7 +177,7 @@ P2P 消息限制独立配置在 `rate.limiter.p2p` 下。
 
 事件投递由 `event.subscribe` 控制。其配置用于选择原生队列或事件插件、插件路径或目标服务器，以及启用的触发器主题。完整配置请参阅[事件订阅](../architecture/event.md)。
 
-Prometheus 监控通过 `node.metrics.prometheus` 配置。该功能默认关闭，启用后监听 `9527` 端口：
+Prometheus 监控通过 `node.metrics.prometheus` 配置。该功能默认关闭；启用后默认监听 `9527` 端口，可通过 `node.metrics.prometheus.port` 修改监听端口：
 
 ```hocon
 node.metrics {

--- a/docs/using_javatron/configuration.md
+++ b/docs/using_javatron/configuration.md
@@ -173,11 +173,26 @@ P2P 消息限制独立配置在 `rate.limiter.p2p` 下。
 
 应将配置文件和 keystore 文件的访问权限限制为节点的操作系统用户，不要将密钥提交到源码仓库，也不要在测试环境中重复使用生产私钥。有关说明，请参阅[启动出块节点](installing_javatron.md#starting-a-block-production-node)和[使用 keystore 指定私钥](installing_javatron.md#keystore-password)。
 
-## 事件订阅与监控
+## 事件订阅与监控 { #event-subscription-and-monitoring }
 
 事件投递由 `event.subscribe` 控制。其配置用于选择原生队列或事件插件、插件路径或目标服务器，以及启用的触发器主题。完整配置请参阅[事件订阅](../architecture/event.md)。
 
-Prometheus 监控配置位于 `node.metrics.prometheus` 下，包括启用开关和监听端口。采集和仪表板说明请参阅[节点监控](metrics.md)。
+Prometheus 监控通过 `node.metrics.prometheus` 配置。该功能默认关闭，启用后监听 `9527` 端口：
+
+```hocon
+node.metrics {
+  prometheus {
+    enable = true
+    port = 9527
+  }
+}
+```
+
+已弃用的 `node.metricsEnable` 配置项独立于 Prometheus 开关。它用于启用旧版 Dropwizard 指标采集，并注册 gRPC `Monitor` 服务（`GetStatsInfo`）。
+
+从 GreatVoyage-v4.8.2 开始，不再支持 InfluxDB reporter。`node.metrics.storageEnable` 和整个 `node.metrics.influxdb` 配置块不再使用，可以从配置文件中删除。
+
+有关指标说明、采集、PromQL 示例和仪表板配置，请参阅[节点监控](metrics.md)。
 
 ## 动态配置重载
 

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -15,7 +15,7 @@ node.metrics = {
 }
 ```
 
-Prometheus 监控默认关闭，启用后监听 `9527` 端口。
+Prometheus 监控默认关闭；启用后默认监听 `9527` 端口，可通过 `node.metrics.prometheus.port` 修改监听端口。
 
 有关 Prometheus 和旧版监控配置的详细说明，请参阅[事件订阅与监控](configuration.md#event-subscription-and-monitoring)。
 

--- a/docs/using_javatron/metrics.md
+++ b/docs/using_javatron/metrics.md
@@ -15,6 +15,10 @@ node.metrics = {
 }
 ```
 
+Prometheus 监控默认关闭，启用后监听 `9527` 端口。
+
+有关 Prometheus 和旧版监控配置的详细说明，请参阅[事件订阅与监控](configuration.md#event-subscription-and-monitoring)。
+
 ## 启动 java-tron 节点
 
 完成配置后，请参考[启动 java-tron 节点](installing_javatron.md#starting-a-java-tron-node)一节启动节点。
@@ -129,6 +133,3 @@ Grafana 可视化工具的部署流程如下：
     ![image](https://raw.githubusercontent.com/tronprotocol/documentation-zh/master/images/metrics_import.png)
     
     随后 Grafana 将根据导入的 JSON 文件渲染出对应的仪表盘，您可以实时监控节点的运行情况。
-
-
-


### PR DESCRIPTION
## Summary

- translate and align the Prometheus, legacy Dropwizard, and InfluxDB configuration guidance
- clarify the default Prometheus listener settings and deprecated legacy monitoring setting
- keep the metrics deployment guide focused by linking to the precise configuration section

## Why

The Chinese monitoring documentation needed to match the clarified English guidance and distinguish the embedded Prometheus HTTP endpoint from the legacy gRPC `Monitor` service.

## Impact

Chinese-language node operators get consistent and more precise monitoring configuration guidance. This is a documentation-only change.

## Validation

- verified the translation against the English documentation change
- ran `mkdocs build --strict`
- ran `git diff --check`
