### PR TITLE
add separate CI workflow documentation based on v4.8.2

### DIFF
--- a/docs/developers/demo.md
+++ b/docs/developers/demo.md
@@ -304,6 +304,33 @@ public class SetPeerServletTest {
 
 ![CheckStyle 代码风格修复后示例](https://raw.githubusercontent.com/tronprotocol/documentation-zh/master/images/demo_codestyle.png)
 
+为了更快获得反馈，可以在仓库根目录运行与 CI 相同的 Checkstyle 任务：
+
+```bash
+./gradlew \
+  :framework:checkstyleMain \
+  :framework:checkstyleTest \
+  :plugins:checkstyleMain
+```
+
+常规构建也会运行 Checkstyle，并执行范围更广的验证任务。在创建 PR 前，请运行完整构建：
+
+```bash
+./gradlew clean build --no-daemon
+```
+
+在 x86-64 环境中，项目要求使用 JDK 8，常规 `test` 任务默认使用 LevelDB。请另行运行有针对性的 RocksDB 引擎测试：
+
+```bash
+./gradlew :framework:testWithRocksDb --no-daemon
+```
+
+在 ARM64 环境中，项目要求使用 JDK 17，`framework` 模块的常规 `test` 任务已经使用 RocksDB。因此，`./gradlew clean build --no-daemon` 已经会使用 RocksDB 运行 `framework` 模块测试，通常无需再运行 `testWithRocksDb`。
+
+GitHub Actions 还会执行一些难以在单台开发机器上完整复现的检查。完整的触发矩阵、覆盖率阈值和分支差异请参阅 [java-tron CI 工作流](workflows.md)。
+
+在请求最终审查前，请确保 PR 的所有必要检查均已通过。
+
 ## 5. 提交代码与 Pull Request
 
 ### 5.1 提交 Commit
@@ -330,4 +357,3 @@ git push origin feature/add-new-http-demo
 ![提交 Pull Request 示例](https://raw.githubusercontent.com/tronprotocol/documentation-zh/master/images/javatron_pr.png)
 
 请确保您的 Pull Request 描述清晰，包含您所做更改的详细信息和目的。
-

--- a/docs/developers/java-tron.md
+++ b/docs/developers/java-tron.md
@@ -149,12 +149,13 @@ git push origin feature/branch_name
 - 在提交前自测
 - 通过标准化测试
 
-CI 工具：
+### 自动化 CI 检查
 
-- Sonar：静态代码分析
-- Travis CI：持续集成检查
+java-tron 使用 GitHub Actions 执行 PR 校验、代码和配置检查、多平台构建、覆盖率门禁、集成和安全测试、审查者分配，以及取消与已关闭但未合并的 PR 相关的任务。具体运行哪些工作流取决于变更文件、事件类型和目标分支。
 
-所有检查通过后，维护者将审查并合并至 `develop`。
+完整的触发矩阵、检查细节、阈值和分支差异请参阅 [java-tron CI 工作流](workflows.md)。
+
+所有检查通过后，维护者将审查 PR，并将其合并到适当的目标分支。
 
 > **编码规范**
 >
@@ -172,11 +173,14 @@ CI 工具：
 
 1. 一个 PR 只处理一件事
 2. 避免超大改动量
-3. 标题：简要描述 PR 目标
-4. 描述：面向 Reviewer，详细说明
-5. 明确需要反馈的部分
-6. 标题首字母不大写
-7. 标题结尾不加句号
+3. 标题使用 `type: description` 或 `type(scope): description` 格式
+4. 标题长度保持在 10～72 个字符之间
+5. `type` 必须是以下之一：`feat`、`fix`、`refactor`、`docs`、`style`、`test`、`chore`、`ci`、`perf`、`build` 或 `revert`
+6. 标题中的描述部分不得以 ASCII 大写字母开头，标题结尾不得使用句号
+7. PR 描述不得少于 20 个字符，并说明改动内容及原因
+8. 明确需要反馈的部分
+
+`scope` 是可选的。未知 `scope` 只会产生警告，审查者分配使用另一套独立的 `scope` 映射。详细规则请参阅 [`scope` 校验和审查者分配](workflows.md)。
 
 ## Commit 描述规范
 
@@ -199,16 +203,19 @@ CI 工具：
 - `refactor`：代码重构
 - `test`：测试代码改动
 - `chore`：构建流程或辅助工具的变更（无生产代码改动）
+- `ci`：CI/CD 配置变更
+- `perf`：性能改进
+- `build`：构建系统或依赖项变更
+- `revert`：撤销之前的改动
 
-`scope` 用于说明改动位置，例如：`protocol`、`api`、`test`、`docs`、`build`、`db`、`net`。若无合适的 scope，可使用 `*`。
+`scope` 用于说明改动位置，例如：`protocol`、`api`、`test`、`vm`、`config`、`db`、`net`。若无合适的 `scope`，可使用 `*`。
 
 ### Subject 规范
 
-1. 不超过 50 个字符
+1. 保持在 10～72 个字符之间，结尾不加句号
 2. 使用动词开头，第一人称现在时（如 `change` 而非 `changed` 或 `changes`）
-3. 首字母小写
-4. 结尾不加句号
-5. 避免无意义 Commit，建议使用 `git rebase` 命令
+3. `subject` 不得以大写字母开头
+4. 避免无意义 Commit，建议使用 `git rebase` 命令
 
 示例
 
@@ -234,6 +241,3 @@ Closes #1234
 ## 行为准则
 
 请保持尊重和建设性，共同营造积极的社区氛围。
-
-
-

--- a/docs/developers/java-tron.md
+++ b/docs/developers/java-tron.md
@@ -160,7 +160,7 @@ java-tron 使用 GitHub Actions 执行 PR 校验、代码和配置检查、多�
 > **编码规范**
 >
 >- 遵循 [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
->- 所有 PR 必须基于 `develop` 分支
+>- PR 的目标分支应根据改动类型选择：常规 PR 应以 `develop` 为目标分支；`release_*` 分支中的缺陷修复 PR 应以相应的 `release_*` 分支为目标分支；发布后的紧急修复 PR 应以相应的 `hotfix/*` 分支为目标分支。
 
 ## 分支命名规范
 
@@ -180,7 +180,7 @@ java-tron 使用 GitHub Actions 执行 PR 校验、代码和配置检查、多�
 7. PR 描述不得少于 20 个字符，并说明改动内容及原因
 8. 明确需要反馈的部分
 
-`scope` 是可选的。未知 `scope` 只会产生警告，审查者分配使用另一套独立的 `scope` 映射。详细规则请参阅 [`scope` 校验和审查者分配](workflows.md)。
+`scope` 是可选的。未知 `scope` 只会产生警告，审查者分配使用另一套独立的 `scope` 映射。详细规则请参阅 [`scope` 校验和审查者分配](workflows.md#scope)。
 
 ## Commit 描述规范
 

--- a/docs/developers/workflows.md
+++ b/docs/developers/workflows.md
@@ -1,0 +1,89 @@
+# java-tron CI 工作流
+
+本文概述贡献者在准备 java-tron Pull Request 时需要了解的 GitHub Actions 检查。如果实现发生变化，应以 java-tron 仓库中的工作流文件为最终依据。
+
+## 工作流何时运行
+
+| 工作流 | PR 目标分支 | 仅修改文档的 PR | 其他触发方式 |
+| --- | --- | --- | --- |
+| PR Check（`pr-check.yml`） | `develop`、`release_**` | 运行 | 推送到 `master` 或 `release_**` |
+| PR Build（`pr-build.yml`） | `master`、`develop`、`release_**` | 跳过 | 手动触发 |
+| 单节点集成测试（`integration-test-single-node.yml`） | `develop`、`release_**` | 跳过 | 推送到 `master` 或 `release_**`；手动触发 |
+| 多节点集成测试（`integration-test-multinode.yml`） | `develop`、`release_**` | 跳过 | 推送到 `master` 或 `release_**`；手动触发 |
+| CodeQL（`codeql.yml`） | `develop` | 跳过 | 推送到 `develop`、`master` 或 `release_**`；每周定时运行 |
+| Math 使用检查（`math-check.yml`） | `develop`、`release_**` | 运行 | 推送到 `master` 或 `release_**`；手动触发 |
+| 审查者分配（`pr-reviewer.yml`） | `develop`、`release_**` | 运行 | 无 |
+| 关闭 PR 时取消工作流（`pr-cancel.yml`） | 任意分支 | 未合并的 PR 关闭时运行 | 无 |
+
+如果 Pull Request 仅修改文档或部分仓库元数据文件，PR Build、两个集成测试工作流和 CodeQL 会被跳过。如果同一 Pull Request 还包含其他文件，符合目标分支条件的工作流会正常运行。PR Check、Math 使用检查、审查者分配和关闭时取消工作流没有此路径排除规则。
+
+## PR 校验和代码检查
+
+对于目标为 `develop` 或 `release_**` 的 PR，PR Check 会强制执行以下标题和描述规则：
+
+- 使用 `type: description` 或 `type(scope): description` 格式。
+- 标题长度保持在 10～72 个字符之间。
+- `type` 必须是 `feat`、`fix`、`refactor`、`docs`、`style`、`test`、`chore`、`ci`、`perf`、`build` 或 `revert`。
+- 标题中的描述部分不得以 ASCII 大写字母开头，标题结尾不得使用句号。
+- PR 描述去除首尾空白后至少包含 20 个字符。
+- 未知 `scope` 只会产生警告，不会导致检查失败。
+
+该工作流还会运行 Checkstyle，并检查 `common/src/main/resources/reference.conf` 的键名格式、嵌套深度、服务端口冲突和配置注释。这些检查也会针对目标为 `develop` 或 `release_**` 且仅修改文档的 PR 运行。
+
+## 多平台构建和覆盖率
+
+由 PR 触发时，PR Build 会在四种环境中执行完整的 Gradle 构建：
+
+| 环境 | 架构 | JDK | 平台相关检查 |
+| --- | --- | --- | --- |
+| macOS 26 | ARM64 | 17 | 常规 `framework` 测试使用 RocksDB |
+| Ubuntu 24.04 | ARM64 | 17 | 常规 `framework` 测试使用 RocksDB |
+| Rocky Linux 8 容器 | x86-64 | 8 | 有针对性的 RocksDB 引擎测试 |
+| Debian 11 容器 | x86-64 | 8 | 有针对性的 RocksDB 测试和覆盖率报告 |
+
+覆盖率门禁要求：
+
+- 变更的 Java 源代码行覆盖率必须高于 60%；没有变更 Java 源代码行时跳过此项门禁。
+- 与基准提交相比，整体覆盖率的下降不得超过 0.1 个百分点。
+
+## 集成、安全和 Math 检查
+
+本套文档对应的源码版本包含两个完整集成测试工作流：
+
+- 单节点工作流针对一个节点运行完整测试集。
+- 多节点工作流针对由三个见证节点组成的环境运行完整测试集。
+
+它们会针对目标为 `develop` 或 `release_**` 且符合路径条件的 PR 运行，也会在推送到 `master` 或 `release_**` 时运行，并且支持手动触发。
+
+CodeQL 仅针对目标为 `develop` 的 PR 运行。此外，它还会在推送到 `develop`、`master` 或 `release_**` 时运行，并且每周定时运行。
+
+Math 使用检查会拒绝直接使用 `java.lang.Math`，并要求贡献者改用 `org.tron.common.math.StrictMathWrapper`。该检查也会针对目标为 `develop` 或 `release_**` 且仅修改文档的 PR 运行。
+
+## `scope` 校验和审查者分配
+
+PR 校验和审查者分配使用不同的 `scope` 列表。PR 校验的已知列表包含 32 个 `scope`，审查者映射表包含 26 个 `scope`：
+
+| 分类 | 数量 | `scope` |
+| --- | ---: | --- |
+| PR 校验和审查者映射均包含 | 24 | `framework`、`chainbase`、`actuator`、`consensus`、`common`、`crypto`、`plugins`、`protocol`、`net`、`db`、`vm`、`tvm`、`api`、`jsonrpc`、`rpc`、`http`、`event`、`config`、`trie`、`metrics`、`test`、`docker`、`lite`、`toolkit` |
+| 仅 PR 校验包含 | 8 | `block`、`proposal`、`log`、`version`、`freezeV2`、`DynamicEnergy`、`stable-coin`、`reward` |
+| 仅审查者映射包含 | 2 | `backup`、`ci` |
+
+未知 PR `scope` 只会产生校验警告。审查者分配使用独立的 `scope` 映射表。
+
+## PR 关闭时取消工作流
+
+当 PR 在未合并的情况下被关闭时，java-tron 会尝试取消以下工作流中处于排队或运行状态的任务：
+
+- PR Build
+- CodeQL
+- 单节点集成测试
+- 多节点集成测试
+
+## Sonar 配置
+
+java-tron 仓库保留了 `sonar-project.properties` 以及用于静态分析的 SonarQube Gradle 插件配置，但 java-tron 的 GitHub Actions 工作流不会调用 Sonar。如果配置了外部 Sonar 或 SonarCloud 集成，则不属于本文所述工作流文件的范围。
+
+## 在本地运行检查
+
+[开发示例](demo.md#4-checkstyle)提供了推荐的 Checkstyle、完整构建和 RocksDB 命令，并说明了 ARM64 与 x86-64 环境之间的 JDK 和存储引擎差异。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -263,6 +263,7 @@ nav:
         - 账户权限管理: mechanism-algorithm/multi-signatures.md
     - java-tron开发: 
         - 开发者指南: developers/java-tron.md
+        - CI 工作流: developers/workflows.md
         - 核心模块: developers/code-structure.md
         - ChainBase 深入解析: developers/chainbase.md
         - P2P 网络深入解析: developers/network.md


### PR DESCRIPTION
## Summary

- Add the Chinese version of the dedicated java-tron CI workflow reference based on GreatVoyage-v4.8.2.
- Align workflow triggers, build environments, coverage gates, integration checks, scope validation, and cancellation behavior with the English documentation.
- Link the new page from the developer guide, local development example, and site navigation.

## Validation

- mkdocs build --strict
- git diff --check