### PR TITLE
align wallet-cli documentation with v4.11.0

### DIFF
--- a/docs/clients/wallet-cli/index.md
+++ b/docs/clients/wallet-cli/index.md
@@ -6,10 +6,11 @@
 
 仓库提供两种实现：
 
-- **[Java CLI](java-cli.md)** —— 原始的全功能实现。它既提供面向用户的交互式 REPL，也提供供脚本
-  调用 Java JAR 的非交互式标准 CLI。
+- **[Java CLI](java-cli.md)** —— 原始实现。它既提供面向用户的交互式 REPL，也提供供脚本通过
+  Java JAR 调用的非交互式标准 CLI；协议功能覆盖最广，包括 TRC-10 发行、链上 DEX 和治理提案。
 - **[TypeScript / npm CLI](typescript-cli.md)** —— 面向智能体优先设计的 Node.js 实现，以
-  `@tron-walletcli/wallet-cli` 发布，采用分组命令、确定的退出码和结构化 JSON 输出。
+  `@tron-walletcli/wallet-cli` 发布，采用分组命令、确定的退出码和结构化 JSON 输出，并原生支持
+  [多签](typescript-cli-multisig.md)与 [GasFree](typescript-cli-gasfree.md) 工作流。
 
 ## 入口对比
 
@@ -39,10 +40,12 @@
 
 ## 选择实现
 
-| 实现 | 命令风格 | 适用场景 |
-|------|----------|----------|
-| [Java CLI](java-cli.md) | `GetAccount` 等交互式命令，或 `get-account` 等标准 CLI 命令 | 完整的 TRON 钱包功能、手动操作以及 Java JAR 集成 |
-| [TypeScript / npm CLI](typescript-cli.md) | `account info`、`tx send` 等分组命令 | 自动化、CI/CD、结构化 JSON 集成以及 AI 智能体 |
+| 实现 | 命令风格 | 功能侧重 | 适用场景 |
+|------|----------|----------|----------|
+| [Java CLI](java-cli.md) | `GetAccount` 等交互式命令，或 `get-account` 等标准 CLI 命令 | 最广泛的协议功能，包括 TRC-10 发行、DEX 和治理/提案 | 手动操作和 Java JAR 集成 |
+| [TypeScript / npm CLI](typescript-cli.md) | `account info`、`tx send` 等分组命令 | 核心钱包操作、多签、GasFree、本地工具和稳定的机器接口 | 自动化、CI/CD、结构化 JSON 集成以及 AI 智能体 |
 
 两种实现有各自独立的安装与运行要求。请继续阅读 [Java CLI 概览](java-cli.md) 或
-[TypeScript / npm CLI 概览](typescript-cli.md)。
+[TypeScript / npm CLI 概览](typescript-cli.md)。有关 TypeScript 实现中对安全敏感的工作流，
+请参见[多签](typescript-cli-multisig.md)、[GasFree](typescript-cli-gasfree.md)和
+[签名与安全](typescript-cli-signing.md)。

--- a/docs/clients/wallet-cli/java-cli.md
+++ b/docs/clients/wallet-cli/java-cli.md
@@ -63,8 +63,7 @@ java -jar java/build/libs/wallet-cli.jar help --command send-coin
 
 ## 全局选项（标准 CLI）
 
-执行修饰类全局选项由 `GlobalOptions` 解析，可以写在命令名**之前或之后**。顶层模式选择器有更严格的
-位置规则，具体说明如下。
+以下选项用于配置标准 CLI 命令：
 
 | 选项 | 取值 | 说明 |
 |------|------|------|
@@ -81,24 +80,17 @@ java -jar java/build/libs/wallet-cli.jar help --command send-coin
 
 说明：
 
-- 执行修饰类选项 `--network`、`--grpc-endpoint`、`--output`、`--wallet`、`--quiet`、
-  `--verbose` 和 `--password-stdin` 可在命令名之前或之后识别。
-- 顶层模式选择器 `--version` 和 `--interactive` 必须写在命令名之前；出现在命令之后时，会被视为
-  命令自身的参数。
-- `--help` 和 `-h` 出现在命令之前时请求全局帮助，出现在命令之后时请求该命令的帮助。
-- 带取值的全局选项（`--output`、`--network`、`--wallet` 和 `--grpc-endpoint`）既可将取值作为
-  下一个 token 给出（`--network nile`），也可内联给出（`--network=nile`）。
-- 带取值的选项不可重复出现；未知的全局选项会被拒绝。
+- 网络、输出、钱包、日志和密码选项可以写在命令名之前或之后。
+- `--version` 和 `--interactive` 应写在命令名之前。
+- `--help` 写在命令之前时显示全局帮助，写在命令之后时显示该命令的帮助。
+- 带取值的选项同时接受 `--network nile` 和 `--network=nile` 两种形式。
 
 ## 鉴权（标准 CLI）
 
 标准 CLI 模式是非交互的，因此从不提示输入密码。构建并签名交易的命令（本文档中标注为**需要鉴权**）
-会自动完成鉴权：
-
-1. 钱包密码从环境变量 `MASTER_PASSWORD` 读取；当传入 `--password-stdin` 时则从 **stdin** 读取
-   （stdin 优先）。
-2. keystore 从 `Wallet/` 目录加载。可用 `--wallet <name|path>` 选择特定钱包，或用
-   `set-active-wallet` 设置一个**活动钱包**（见 [钱包管理](wallet-management.md)）。
+从 `MASTER_PASSWORD` 读取钱包密码；传入 `--password-stdin` 时则从 stdin 读取，且 stdin 优先。
+可用 `--wallet <name|path>` 选择钱包，或用 `set-active-wallet` 设置一个**活动钱包**
+（见[钱包管理](wallet-management.md)）。
 
 大多数只读查询命令不需要鉴权。例外是作用于当前钱包的查询：`get-address` 始终需要鉴权，
 `get-balance` / `get-usdt-balance` / `gas-free-info` 在省略 `--address` 时需要鉴权
@@ -135,12 +127,8 @@ REPL 的鉴权方式不同：通过 `Login` / `LoginAll` 交互式登录，会�
 }
 ```
 
-其他规则：
-
-- 广播交易的命令会在 `data` 中包含交易 ID `txid`（仅限单签广播）。
-- `deploy-contract` 会在 `data` 中包含部署得到的 `contract_address`。
-- 当某个选项的别名被解析时，信封会包含一个 `meta.resolved` 数组描述解析结果（见
-  [钱包管理](wallet-management.md) 中的别名系统）。
+交易命令可能在 `data` 中加入 `txid` 或 `contract_address` 等标识符。别名解析详情可能出现在
+`meta.resolved` 下（见[钱包管理](wallet-management.md)）。
 
 退出码：
 
@@ -150,13 +138,12 @@ REPL 的鉴权方式不同：通过 `Login` / `LoginAll` 交互式登录，会�
 | `1` | 执行错误（`"error": "execution_error"` 等）。 |
 | `2` | 用法错误（`"error": "usage_error"`——标志错误、缺少必填选项等）。 |
 
-这使得标准 CLI 可安全地用脚本驱动：检查退出码，并从 stdout 解析这唯一的 JSON 对象即可。
+脚本应检查退出码，并解析 stdout 中的 JSON 对象。
 
 ## 网络与配置
 
-各网络的默认节点端点以及其他默认值，位于 `java/src/main/resources/config.conf`（HOCON 格式）。
-`--network` 标志在 `main`、`nile`（测试网）、`shasta`（测试网）和 `custom` 之间选择。对于
-`custom`，用 `--grpc-endpoint host:port` 提供端点。
+`--network` 标志可选择 `main`、`nile`（测试网）、`shasta`（测试网）或 `custom`。使用自定义网络时，
+通过 `--grpc-endpoint host:port` 提供节点端点。
 
 在 REPL 中，用 `SwitchNetwork` 切换网络，用 `CurrentNetwork` 查看当前网络。
 

--- a/docs/clients/wallet-cli/staking.md
+++ b/docs/clients/wallet-cli/staking.md
@@ -14,11 +14,8 @@ TRON 账户质押（冻结）TRX 以获取**带宽**和**能量**，并获得投
 | `1` | ENERGY（能量） |
 | `2` | TRON_POWER（投票权；仅 freeze/unfreeze，且受网络开关限制） |
 
-码 `2`（TRON_POWER）对 freeze/unfreeze 命令受网络开关限制：
-`FreezeBalance`/`UnfreezeBalance`（Stake 1.0）、`FreezeBalanceV2`/`UnfreezeBalanceV2`（Stake 2.0）
-以及对应的标准 CLI 命令，只有在链参数 `getAllowNewResourceModel` 启用时才接受它。如果无法获取该链参数，
-客户端会 fail-open，让节点在广播时进行最终校验。代理命令（两种模式）始终只接受 `0` 或 `1`；
-TRON_POWER 不可代理。
+只有网络启用新资源模型时，freeze 和 unfreeze 命令才可使用码 `2`。代理只接受 `0` 或 `1`；
+TRON_POWER 不能代理。
 
 金额以 **SUN** 为单位（1 TRX = 1,000,000 SUN）。
 
@@ -41,8 +38,7 @@ TRON_POWER 不可代理。
     ```
 
     - `--amount`（必填，SUN）、`--duration`（必填，天）。
-    - `--resource`（可选，`0`/`1`/`2`，默认 `0`）。`2` 是 TRON_POWER，仅在
-      `getAllowNewResourceModel` 启用时允许。如果设置了 `--receiver`，该操作属于代理，`2` 会被拒绝。
+    - `--resource`（可选，`0`/`1`/`2`，默认 `0`）。使用 `--receiver` 时只能选择 `0` 或 `1`。
     - `--receiver`（可选）—— 把获得的资源代理给另一个地址。
     - `--owner`、`--multi`（可选）。
 
@@ -52,8 +48,6 @@ TRON_POWER 不可代理。
     FreezeBalance [OwnerAddress] frozen_balance frozen_duration [ResourceCode] [receiverAddress]
     ```
 
-    `ResourceCode`：`0` BANDWIDTH，`1` ENERGY，`2` TRON_POWER。
-
 ### 解冻余额 —— `unfreeze-balance` / `UnfreezeBalance`
 
 === "标准 CLI"
@@ -62,8 +56,7 @@ TRON_POWER 不可代理。
     java -jar java/build/libs/wallet-cli.jar --network nile unfreeze-balance --resource 1
     ```
 
-    - `--resource`（可选，`0`/`1`/`2`，默认 `0`）。`2` 是 TRON_POWER，仅在
-      `getAllowNewResourceModel` 启用时允许。如果设置了 `--receiver`，该操作针对代理冻结，`2` 会被拒绝。
+    - `--resource`（可选，`0`/`1`/`2`，默认 `0`）。使用 `--receiver` 时只能选择 `0` 或 `1`。
     - `--receiver`（可选）—— 若该资源曾被代理则必填。
     - `--owner`、`--multi`（可选）。
 
@@ -87,8 +80,6 @@ TRON_POWER 不可代理。
     ```
 
     - `--amount`（必填，SUN）、`--resource`（可选，`0`/`1`/`2`，默认 `0`）。
-      `2` 是 TRON_POWER，仅在 `getAllowNewResourceModel` 启用时允许；如果无法获取该链参数，客户端会让节点
-      在广播时校验。
     - `--owner`、`--permission-id`、`--multi`（可选）。
 
 === "交互模式"
@@ -109,8 +100,6 @@ TRON_POWER 不可代理。
     ```
 
     - `--amount`（必填，SUN）、`--resource`（可选，`0`/`1`/`2`，默认 `0`）。
-      `2` 是 TRON_POWER，仅在 `getAllowNewResourceModel` 启用时允许；如果无法获取该链参数，客户端会让节点
-      在广播时校验。
     - `--owner`、`--permission-id`、`--multi`（可选）。
 
 === "交互模式"
@@ -178,7 +167,7 @@ TRON_POWER 不可代理。
     DelegateResource [OwnerAddress] balance ResourceCode ReceiverAddress [lock] [lockPeriod]
     ```
 
-    `ResourceCode`：`0` BANDWIDTH，`1` ENERGY。`lock` 为 `true`/`false`。
+    `lock` 为 `true` 或 `false`。
 
 ### 取消代理资源 —— `undelegate-resource` / `UnDelegateResource`
 

--- a/docs/clients/wallet-cli/typescript-cli-gasfree.md
+++ b/docs/clients/wallet-cli/typescript-cli-gasfree.md
@@ -1,0 +1,106 @@
+# TypeScript CLI GasFree
+
+GasFree 允许账户在没有 TRX 的情况下转移受支持的 token。GasFree 服务负责提交转账，并从转移的
+token 中收取服务费。
+
+该工作流与 [Java CLI GasFree](gasfree.md) 中介绍的 Java 命令相互独立。
+
+## 配置服务
+
+GasFree 支持 TRON 主网和 Nile，不支持 Shasta。请为所选主网或测试网环境配置凭据：
+
+```bash
+wallet-cli config gasfreeApiKey '<api-key>'
+wallet-cli config gasfreeApiSecret '<api-secret>'
+```
+
+显示配置时，API 凭据会被隐藏。请保护 `config.yaml`；在 POSIX 系统上，如果包含该凭据的
+配置文件权限不安全，wallet-cli 会拒绝使用。
+
+## 获取 GasFree 地址和费用
+
+GasFree 服务会为每个钱包账户提供一个专属地址。用于该工作流的 token 必须发送到这个地址，而不是
+账户的普通 TRON 地址。
+
+查询地址、激活状态、支持的 token 和当前费用：
+
+```bash
+wallet-cli gasfree info --account main --network tron:nile
+```
+
+服务会收取：
+
+- 每笔转账的服务费；
+- 未激活 GasFree 地址首次转出时的一次性激活费。
+
+两项费用都使用转账 token 支付，并计入所需总额。费用和支持的 token 可能变化，因此应在转账前立即
+查询或试运行。
+
+## 预览和提交转账
+
+使用 `--dry-run` 检查费用，并确认 GasFree 地址中的 token 余额是否充足：
+
+```bash
+wallet-cli gasfree transfer \
+  --to TRecipient... \
+  --amount 25 \
+  --token USDT \
+  --network tron:nile \
+  --dry-run
+```
+
+余额必须能够支付接收方金额、服务费以及可能产生的激活费。
+
+检查结果后，再签名并提交：
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli gasfree transfer \
+    --to TRecipient... \
+    --amount 25 \
+    --token USDT \
+    --network tron:nile \
+    --password-stdin
+```
+
+`--to` 也接受通过 `contact add` 保存的名称。
+
+Ledger 账户支持 GasFree 签名。使用 Ledger 账户时不要传入 `--password-stdin`，并在 Ledger TRON
+应用中启用 **Settings > Sign by Hash > Allowed**。
+
+GasFree 不支持 `--sign-only` 或 `--build-only`。其授权会提交给 GasFree 服务，而不是像普通交易
+那样以签名交易数据的形式广播。
+
+## 跟踪转账
+
+提交操作返回 GasFree `traceId`，而不是链上交易 ID。转账可能仍在等待服务或网络处理：
+
+```bash
+wallet-cli gasfree trace <TRACE_ID> --network tron:nile
+```
+
+也可以为 `gasfree transfer` 添加 `--wait`。
+
+服务通过 `WAITING`、`INPROGRESS` 和 `CONFIRMING` 报告进度，`SUCCEED` 和 `FAILED`
+是最终状态。轮询时可能跳过中间状态。
+
+不要把 GasFree trace id 传给 `tx status`。应继续使用 `gasfree trace`，直到服务返回最终状态。
+服务提交交易后，响应中才会出现链上交易 ID。
+
+自动化程序应检查返回的 `state` 或 `stage`。状态查询本身成功，并不代表转账一定成功。
+
+## 检查清单
+
+- 使用 `gasfree info` 获取正确的收款地址和当前费用。
+- 分开保管主网和 Nile 凭据。
+- 发送前立即进行试运行。
+- 确认余额能够支付金额和全部费用。
+- 在请求达到最终状态之前，将已提交请求视为待处理。
+- 在主网上签名前，确认接收方、token、金额和费用。
+
+所有选项和响应字段，请参见上游
+[`gasfree info`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/gasfree/info.md)、
+[`gasfree transfer`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/gasfree/transfer.md)
+以及
+[`gasfree trace`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/gasfree/trace.md)
+参考。

--- a/docs/clients/wallet-cli/typescript-cli-multisig.md
+++ b/docs/clients/wallet-cli/typescript-cli-multisig.md
@@ -1,0 +1,192 @@
+# TypeScript CLI 多签
+
+TypeScript CLI 可以查看和替换账户权限、为所选权限构建交易、收集带权重的签名，并在达到阈值后
+广播交易。
+
+签名者可以直接交换交易文件，也可以使用可选的 TronLink 多签服务。
+
+## 权限与费用
+
+一个 TRON 账户可以拥有：
+
+- 一个 owner 权限，ID 为 `0`；
+- 一个可选的 witness 权限，ID 为 `1`；
+- 最多八个 active 权限，ID 为 `2`–`9`。
+
+每个权限最多可以包含五个密钥。每个密钥都有权重，签名的合计权重必须达到该权限的阈值。
+
+有两项链上费用与多签尤其相关：
+
+- 替换账户权限结构目前在主网上收取 **100 TRX**；
+- 广播包含多个签名的交易目前在主网上额外收取 **1 TRX**。
+
+这些都是可能变化的链参数，wallet-cli 会在运行时读取当前值。
+
+## 查看和更新权限
+
+创建或签名交易前先查看账户权限：
+
+```bash
+wallet-cli permission show --account main --network tron:nile
+wallet-cli permission show --account main --network tron:nile --output json
+```
+
+`permission update` 会替换完整的权限结构。先导出当前结构，只修改需要变更的字段，然后对替换操作
+进行试运行：
+
+```bash
+wallet-cli permission show --account main --network tron:nile --output json |
+  jq '.data' > permissions.json
+
+$EDITOR permissions.json
+
+wallet-cli permission update \
+  --file permissions.json \
+  --account main \
+  --network tron:nile \
+  --dry-run
+```
+
+请保留不准备修改的字段，并检查完整的试运行结果。修改允许执行的操作时，请遵循上游
+[`permission` 参考](https://github.com/tronprotocol/wallet-cli/tree/master/ts/docs/commands/permission)，
+因为相关字段必须保持一致。如果 `permission show` 报告未知操作，除非能够保留其位图，否则不要
+修改该 active 权限。检查密钥、权重、阈值、允许执行的操作和费用后，再提交更新：
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli permission update \
+    --file permissions.json \
+    --account main \
+    --network tron:nile \
+    --wait \
+    --password-stdin
+```
+
+!!! danger
+    权限更新可能永久锁定账户，且链上没有恢复机制。请确认新的 owner 权限包含预期密钥，并且现有
+    签名者能够达到其阈值。
+
+## 交换交易文件
+
+直接交换文件的工作流不需要外部协作服务。
+
+### 1. 创建第一个交易文件
+
+选择权限，为协同签名预留足够时间，并创建第一个签名：
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli tx send \
+    --to TRecipient... \
+    --amount 1000 \
+    --permission-id 2 \
+    --sign-only \
+    --expiration 86400000 \
+    --network tron:nile \
+    --password-stdin \
+    --output text > transaction.hex
+```
+
+交易默认约 60 秒后过期。手动收集签名时，应设置足以让所有签名者完成操作的过期时间，最长 24 小时。
+如果第一个签名者在其他机器上，请使用 `--build-only`，而不是 `--sign-only`。
+
+### 2. 检查签名
+
+```bash
+wallet-cli tx approvals --file transaction.hex --network tron:nile
+```
+
+该命令会显示权限、已签名者、累计权重、缺少的权重和过期时间。过期交易仍可查看，但不能继续签名或
+广播。
+
+### 3. 添加签名
+
+每位签名者使用上一位签名者生成的最新文件：
+
+```bash
+printf '%s\n' "$COSIGNER_PASSWORD" |
+  wallet-cli tx sign \
+    --file transaction.hex \
+    --account cosigner \
+    --network tron:nile \
+    --out transaction.signed.hex \
+    --password-stdin
+```
+
+在线签名会检查签名者是否属于该权限，并拒绝重复签名。在与网络隔离的机器上添加 `--offline`，之后再
+通过 `tx approvals` 检查交易文件。
+
+### 4. 验证并广播
+
+当 `thresholdReached` 为 true 时，验证并广播最终交易文件：
+
+```bash
+wallet-cli tx broadcast --file transaction.signed.hex --network tron:nile --dry-run
+wallet-cli tx broadcast --file transaction.signed.hex --network tron:nile --wait
+```
+
+wallet-cli 会拒绝过期交易或签名权重低于阈值的交易。
+
+## 使用 TronLink 服务
+
+`tx multisig` 可以保存交易、协调签名并通知协同签名者。请配置与所选主网或测试网环境匹配的凭据：
+
+```bash
+wallet-cli config tronlinkSecretId '<secret-id>'
+wallet-cli config tronlinkSecretKey '<secret-key>'
+wallet-cli config tronlinkChannel '<channel>'
+```
+
+构建未签名交易文件并创建签名集合：
+
+```bash
+wallet-cli tx send \
+  --to TRecipient... \
+  --amount 1000 \
+  --permission-id 2 \
+  --build-only \
+  --expiration 86400000 \
+  --network tron:nile \
+  --output text > transaction.unsigned.hex
+
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli tx multisig \
+    --create \
+    --file transaction.unsigned.hex \
+    --network tron:nile \
+    --password-stdin
+```
+
+创建签名集合时会添加发起人的第一个签名。其他签名者可以列出请求，并按交易 ID 签名：
+
+```bash
+wallet-cli tx multisig --account cosigner --network tron:nile
+
+printf '%s\n' "$COSIGNER_PASSWORD" |
+  wallet-cli tx multisig \
+    --sign <TX_ID> \
+    --account cosigner \
+    --network tron:nile \
+    --password-stdin
+```
+
+使用 `tx multisig --watch` 接收通知。达到阈值后，服务会自动广播。尝试手动广播前，请先确认交易
+已经上链。
+
+## 安全检查清单
+
+- 选择或修改权限前，先查看当前权限。
+- 对完整的权限替换操作进行试运行并检查结果。
+- 只把最新交易文件传给下一位签名者；修改交易会使之前的签名失效。
+- 选择足够完成签名收集、但不超过必要时长的过期时间。
+- 检查 `thresholdReached`，而不是签名数量，因为不同密钥的权重可能不同。
+- 在主网上签名或广播前，确认接收方、金额、权限和费用。
+
+所有选项和响应字段，请参见上游
+[`permission`](https://github.com/tronprotocol/wallet-cli/tree/master/ts/docs/commands/permission)、
+[`tx sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/sign.md)、
+[`tx approvals`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/approvals.md)、
+[`tx multisig`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/multisig.md)
+以及
+[`tx broadcast`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/broadcast.md)
+参考。

--- a/docs/clients/wallet-cli/typescript-cli-signing.md
+++ b/docs/clients/wallet-cli/typescript-cli-signing.md
@@ -1,60 +1,55 @@
 # TypeScript CLI 签名与安全
 
-TypeScript CLI 支持软件 keystore、Ledger 账户和 watch-only 账户。软件私钥始终在本地加密保存，
-Ledger 私钥绝不会离开设备，watch-only 账户可以查询状态，但不能签名。
+TypeScript CLI 支持软件账户、Ledger 账户和 watch-only 账户。软件密钥始终在本地加密保存，Ledger
+密钥保留在设备上，watch-only 账户不能签名。
 
-## 签名现有交易 {#sign-an-existing-transaction}
+## 签名交易
 
-`tx sign` 可以签名在 wallet-cli 之外构建的 TRON 交易，但不会广播：
+`tx sign` 接受两种输入形式：
 
-```bash
-printf '%s\n' "$WALLET_PASSWORD" |
-  wallet-cli tx sign --transaction "$TX_JSON" --password-stdin --output json
-```
-
-对于软件账户，签名可以离线完成，`--network` 为可选项。该命令是一个纯签名器：它不会判断签名者
-是否拥有该交易、合约调用是否符合预期，也不会判断应转移多少价值。调用方仍需负责策略检查。
-
-### 交易完整性
-
-TRON 交易通过三个相互关联的字段表示其内容：
-
-| 字段 | 用途 |
+| 输入 | 用途 |
 |------|------|
-| `raw_data` | 供用户和应用读取的交易内容。 |
-| `raw_data_hex` | 节点实际执行的字节。 |
-| `txID` | 签名覆盖的哈希。 |
+| `--transaction <json>` | 直接签名 JSON 交易。 |
+| `--hex <hex>` / `--file <path>` | 向交易数据添加签名。 |
 
-签名前，wallet-cli 要求 `txID` 等于 `raw_data_hex` 的 SHA-256 哈希。它还会解码交易的外层封装，
-并要求 `raw_data` 声明的合约类型与 `raw_data_hex` 中编码的类型一致。对于可以重新编码的合约类型，
-它还要求 `raw_data` 的字段级内容重新编码后得到相同字节。任何不一致都会返回 `tx_integrity`，且不会
-生成签名。
+该命令只签名，不会广播。之后使用 `tx broadcast` 广播。
 
-底层库无法重新编码 `MarketSellAssetContract`、`MarketCancelOrderContract` 和
-`ShieldedTransferContract`。wallet-cli 仍会检查这类交易的哈希和合约类型，但无法将其 `raw_data`
-字段值与 `raw_data_hex` 对照验证；调用方必须把显示的这些字段值视为未经验证的数据。
-
-### 多签交易
-
-如果输入已经包含 `signature` 数组，`tx sign` 会追加新签名，而不是替换已有签名。因此，同一笔部分
-签名的交易可以依次传递给多个授权签名者，直到达到权限阈值。
-
-提取已签名的载荷，稍后再广播：
+软件账户通过 stdin 提供密码：
 
 ```bash
 printf '%s\n' "$WALLET_PASSWORD" |
-  wallet-cli tx sign --transaction "$TX_JSON" --password-stdin --output json |
-  jq -c '.data.signed' > signed.json
-
-wallet-cli tx broadcast --network tron:nile --tx-stdin < signed.json
+  wallet-cli tx sign \
+    --transaction "$TX_JSON" \
+    --password-stdin
 ```
 
-文本输出会打印完整签名，而不是缩写的交易标识符。
+对于多签交易数据，已有签名会保留，所选账户再添加一个签名：
+
+```bash
+printf '%s\n' "$WALLET_PASSWORD" |
+  wallet-cli tx sign \
+    --file transaction.hex \
+    --account cosigner \
+    --network tron:nile \
+    --out transaction.signed.hex \
+    --password-stdin
+```
+
+对交易数据签名时，CLI 默认会在线检查所选权限和已有签名，并拒绝过期交易、未授权签名者或重复签名。
+在与网络隔离的设备上使用 `--offline`，之后再通过 `tx approvals` 检查交易数据。
+
+完整的协同签名流程见 [TypeScript CLI 多签](typescript-cli-multisig.md)。
+
+## 签名前检查
+
+wallet-cli 会在签名前验证交易表示。无法安全解码和验证的十六进制或文件形式的交易数据会被拒绝。
+
+签名前务必确认发送方、接收方、金额、token 或合约、权限和过期时间。离线签名时，应通过可信渠道
+传递交易数据，并且不要在签名者之间修改交易内容。
 
 ## 签名类型化数据
 
-`typed-data sign` 用于签名 EIP-712/TIP-712 结构化数据，并返回签名者地址、推断或声明的主类型、
-摘要和签名：
+`typed-data sign` 用于签名 EIP-712/TIP-712 结构化数据：
 
 ```bash
 printf '%s\n' "$WALLET_PASSWORD" |
@@ -64,65 +59,47 @@ printf '%s\n' "$WALLET_PASSWORD" |
     --output json
 ```
 
-载荷采用常见的 `domain`、`types`、`primaryType` 和 `message` 结构。CLI 会：
+载荷使用 `domain`、`types`、`primaryType` 和 `message`。地址字段接受 TRON Base58 地址。
+`domain.chainId` 会按输入值参与签名，不会与 `--network` 比较，因此请仔细检查 domain 和 message。
 
-- 忽略 `types` 中的 `EIP712Domain`；
-- 接受 `value` 作为 `message` 的别名；
-- 在 `address` 字段中接受 TRON Base58 地址；
-- 在省略 `primaryType` 时进行推断，并报告最终解析出的类型；
-- 拒绝不是消息根类型的已声明 `primaryType`。
+## Ledger 账户
 
-`domain.chainId` 会严格按输入值参与签名，不会与 `--network` 比较。签名前请检查 domain 和 message。
+Ledger 账户支持交易和类型化数据签名。使用 Ledger 账户时，不要通过管道传入密码，也不要使用
+`--password-stdin`。
 
-## Ledger 行为
+签名类型化数据时，请在 Ledger TRON 应用中启用
+**Settings > Sign by Hash > Allowed**。设备可能只显示哈希，而不会显示类型化数据的每个字段，因此
+批准操作前应在主机上核对完整载荷。
 
-`tx sign` 和 `typed-data sign` 均支持 Ledger 账户。交易完整性检查同样会在软件签名和 Ledger
-签名之前执行。
+其他操作可能要求在 TRON 应用中启用相应的交易或自定义合约签名设置。如果应用或设备无法签名某项
+操作，wallet-cli 会返回包含处理建议的 Ledger 错误。
 
-类型化数据签名使用 TRON 应用的哈希签名能力。请在设备上启用
-**Settings > Sign by Hash > Allowed**，否则 CLI 会返回 `ledger_setting_required`。如果 TRON
-应用版本不支持该指令，则返回 `ledger_unsupported`。
+## 密码与敏感信息输入
 
-交易数据或自定义合约签名等其他 Ledger 应用设置，也会以可采取操作的
-`ledger_setting_required` 错误报告，而不是返回含义不清的 APDU 错误。设备超时或取消操作后会关闭
-传输连接，使后续尝试可以正常重新连接。
+Master password、助记词和私钥绝不会通过命令行参数或配置值接收。
 
-Ledger 屏幕无法显示类型化数据的全部字段，可能只显示哈希。批准操作前，请在主机上核对载荷。
+软件账户签名必须使用 `--password-stdin`。没有显式交互式密码流程的命令在缺少密码标志时不会提示。
 
-## Secret 输入策略
-
-Secret 绝不会通过命令行参数或环境配置接收。
-
-支持的 stdin 通道如下：
+单次调用只能使用一个 stdin 标志：
 
 | 标志 | 输入 |
 |------|------|
-| `--password-stdin` | 用于解锁软件 keystore 的 master password。 |
-| `--tx-stdin` | `tx broadcast` 消费的已签名交易 JSON。 |
-| `--message-stdin` | `message sign` 消费的消息。 |
+| `--password-stdin` | 软件钱包 master password。 |
+| `--tx-stdin` | `tx broadcast` 使用的交易 JSON。 |
+| `--message-stdin` | `message sign` 使用的消息。 |
 
-单次调用中只能有一个 `*-stdin` 标志消费 stdin。
+`import mnemonic`、`import private-key` 和 `change-password` 要求在真实终端中进行隐藏输入。
 
-以下高敏感度的初始化操作只能交互执行，并要求从真实 TTY 隐藏输入：
+## 保护本地数据
 
-- `import mnemonic`
-- `import private-key`
-- `change-password`
+- 钱包文件、备份和生成的密钥对包含敏感信息。请安全保存，不要共享。
+- `config.yaml` 中的服务凭据在显示时会被隐藏。请保护配置文件。
+- 已签名交易文件不包含私钥，但分享或广播前仍应检查其内容。
+- 仅在受控的离线终端中使用 `--print-secret`。
 
-它们不接受 `--mnemonic-stdin`、`--private-key-stdin` 或 `--password-stdin`。没有 TTY 时，
-命令会返回 `tty_required`。
-
-## 失败行为
-
-- watch-only 账户会在签名或写操作开始前返回 `watch_only_no_signer`。
-- 无效的全局选项值会返回 `invalid_value`，而不是退回默认值。
-- Ledger 设置和版本问题分别使用 `ledger_setting_required` 和 `ledger_unsupported`。
-- 交易的多种表示不一致时返回 `tx_integrity`。
-- 用户或设备拒绝签名时返回 `signing_rejected`。
-
-JSON 模式会在单个 `wallet-cli.result.v1` 信封中返回这些错误码；执行失败使用退出码 1，无效用法
-使用退出码 2。
-
-完整的字段级命令参考，请参见
-[`tx sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/sign.md) 和
-[`typed-data sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/typed-data/sign.md)。
+所有选项和响应字段，请参见上游
+[`tx sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/sign.md)、
+[`tx approvals`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/tx/approvals.md)
+以及
+[`typed-data sign`](https://github.com/tronprotocol/wallet-cli/blob/master/ts/docs/commands/typed-data/sign.md)
+参考。

--- a/docs/clients/wallet-cli/typescript-cli.md
+++ b/docs/clients/wallet-cli/typescript-cli.md
@@ -1,11 +1,10 @@
 # TypeScript / npm CLI
 
-从 `wallet-cli` 仓库的 4.9.7 发布版本开始，仓库同时提供一个面向智能体优先设计的 TypeScript CLI。
-该 CLI 以 npm 包 `@tron-walletcli/wallet-cli` 发布，并采用独立的 npm 版本号；`wallet-cli --version`
-显示的是 npm 包版本。它与本节其他页面介绍的 Java JAR 是两套命令面：Java CLI 使用 `send-coin`
-这类命令，而 TypeScript CLI 使用 `tx send` 这类分组命令。
+从 4.9.7 版本开始，`wallet-cli` 仓库同时提供 TypeScript CLI，并以 npm 包
+`@tron-walletcli/wallet-cli` 发布。从 4.10.1 开始，npm 包版本与 wallet-cli 发布版本保持一致。
 
-当前 TypeScript CLI 支持 TRON 主网、Nile 和 Shasta，尚不支持 EVM 链。
+TypeScript CLI 与 Java JAR 相互独立，使用 `tx send` 等分组命令。它支持 TRON 主网、Nile 和 Shasta，
+不支持 EVM 链。
 
 ## 安装
 
@@ -19,56 +18,43 @@ wallet-cli --help
 
 ## 快速开始
 
-创建本地 HD 钱包，选择该钱包，并使用 Nile 进行测试交易：
+创建钱包、选择钱包，并使用 Nile 进行测试：
 
 ```bash
 wallet-cli create --label main
 wallet-cli list
 wallet-cli use main
-wallet-cli current
 wallet-cli config defaultNetwork tron:nile
 wallet-cli account balance
 ```
 
-也可以只为某一条命令临时指定网络，而不修改默认网络：
+使用 `--network` 可以只为一条命令临时指定网络：
 
 ```bash
 wallet-cli account balance --network tron:nile
 ```
 
-## 全局选项
-
-常用全局选项包括：
+## 常用选项
 
 | 选项 | 说明 |
-|--------|-------------|
-| <code>--output text&#124;json</code>, <code>-o</code> | 选择 text 或 JSON 输出。 |
-| `--network` | 网络 ID，例如 `tron:mainnet`、`tron:nile` 或 `tron:shasta`。 |
-| `--account` | 账户 ID、标签或地址；默认使用 `use` 设置的 active account。 |
-| `--timeout` | 每次 RPC/设备调用的超时时间，单位为毫秒。 |
-| `--verbose`, `-v` | 输出更多诊断信息。 |
-| `--wait` | 广播后轮询，直到交易 confirmed 或 failed。 |
-| `--wait-timeout` | `--wait` 轮询的上限，单位为毫秒；默认使用 `config.waitTimeoutMs`（内置值为 60000）。 |
-| `--password-stdin` | 从 stdin 读取 master password。 |
+|------|------|
+| <code>--output text&#124;json</code>、<code>-o</code> | 选择文本或 JSON 输出。 |
+| `--network` | 选择 `tron:mainnet`、`tron:nile` 或 `tron:shasta`。 |
+| `--account` | 按 ID、标签或地址选择账户。 |
+| `--wait` | 提交后轮询，直到出现最终状态或达到等待超时。 |
+| `--password-stdin` | 从 stdin 读取软件钱包密码。 |
 
-命令级 stdin 标志为 `--tx-stdin` 和 `--message-stdin`。它们与全局的 `--password-stdin`
-合计只能有一个 `*-stdin` 标志在单次调用中消费 stdin。
-
-可以使用 `wallet-cli config` 持久化默认值。例如：
+使用 `wallet-cli config` 查看或持久化默认值：
 
 ```bash
+wallet-cli config
 wallet-cli config waitTimeoutMs 90000
 ```
 
 ## 钱包和账户
 
-TypeScript CLI 默认把数据保存在 `~/.wallet-cli`。可通过 `WALLET_CLI_HOME` 隔离测试或自动化数据。
-
-```bash
-WALLET_CLI_HOME=/tmp/wallet-cli-demo wallet-cli list --output json
-```
-
-常用钱包命令：
+钱包数据默认保存在 `~/.wallet-cli`。可以设置 `WALLET_CLI_HOME` 使用其他位置，例如隔离测试或
+自动化数据。
 
 ```bash
 wallet-cli create --label main
@@ -84,27 +70,36 @@ wallet-cli backup primary --out ~/primary-backup.json
 wallet-cli change-password
 ```
 
-`import mnemonic`、`import private-key` 和 `change-password` 只能交互执行。它们要求使用真实终端，
-并通过隐藏提示读取 secret，不提供非交互式 stdin 替代方式。
+助记词和私钥导入以及密码修改需要真实终端，并通过隐藏提示读取输入。这些敏感信息不能通过命令行参数传入。
 
-以非交互方式使用 `derive`、`backup` 和 `tx sign` 等命令时，通过 `--password-stdin` 传入 master
-password。使用 Ledger 账户签名时，不要通过管道传入密码，也不要传入 `--password-stdin`。下方
-`derive` 示例展示了完整的非交互式写法。为了保持后续示例简洁，其中可能省略密码输入管道和
+对于没有交互式密码流程、需要签名或解密密钥的命令，软件账户必须通过 `--password-stdin` 提供
+master password。备份既可以使用终端隐藏提示，也可以使用 `--password-stdin`。Ledger 账户不使用
 `--password-stdin`。
 
-派生 HD 子账户时，需要传入 `wallet-cli list` 显示的 HD seed id。
+为使后续命令清单保持简洁，签名示例可能省略密码管道和 `--password-stdin`。软件账户必须补上它们；
+Ledger 账户则不能添加。
+
+派生 HD 子账户时，传入 `wallet-cli list` 显示的 seed id：
 
 ```bash
 printf '%s\n' "$WALLET_PASSWORD" |
   wallet-cli derive --seed-id wlt_ab12cd34 --label operations --password-stdin
 ```
 
-删除根 HD 钱包会级联删除从该根派生出的账户，并清理孤立标签。在非交互式 shell 中需要传入 `--yes`；
-否则命令会要求确认。
+使用 `wallet-cli delete` 删除账户。删除根 HD 钱包时，也会删除从中派生的账户。仅在明确希望跳过确认时
+使用 `--yes`。
+
+CLI 可以激活新地址，还可以设置所选账户的链上名称或 ID：
 
 ```bash
-wallet-cli delete old --yes
+wallet-cli account activate --address TNewAddress... --network tron:nile --dry-run
+wallet-cli account set --name "Acme Treasury" --network tron:nile --dry-run
+wallet-cli account set --id acme-treasury-01 --network tron:nile --dry-run
 ```
+
+`account activate` 会向所选账户收取当前的账户创建费。链上账户名称和 ID 都只能设置一次。这与
+`rename` 不同，后者只修改可重复更改的本地标签。`account activate` 和 `account set --id` 不能由
+Ledger 账户签名。提交前请先使用 `--dry-run` 检查这些操作。
 
 ## 交易
 
@@ -112,72 +107,85 @@ wallet-cli delete old --yes
 
 ```bash
 wallet-cli tx send --to T... --amount 1 --dry-run
-wallet-cli tx send --to T... --amount 1 --wait
-wallet-cli tx send --to T... --token USDT --amount 5
-wallet-cli tx send --to T... --contract TR7... --amount 5
-wallet-cli tx send --to T... --asset-id 1002000 --raw-amount 1000000
+wallet-cli tx send --to T... --token USDT --amount 5 --dry-run
+wallet-cli tx send --to T... --contract TR7... --amount 5 --dry-run
+wallet-cli tx send --to T... --asset-id 1002000 --raw-amount 1000000 --dry-run
 ```
 
-交易构建命令支持三种执行模式：
+交易构建命令支持四种模式：
 
 | 模式 | 行为 |
-|------|----------|
+|------|------|
 | 默认 | 构建、签名并广播。 |
 | `--dry-run` | 构建并估算，不签名、不广播。 |
-| `--sign-only` | 签名并输出交易，但不广播。 |
+| `--sign-only` | 构建并签名，不广播。 |
+| `--build-only` | 构建交易，不签名，也不解锁钱包。 |
 
-默认模式在交易提交后返回。添加 `--wait` 后，CLI 会轮询 FullNode 的未确认视图，直到交易确认或失败。
-如果达到轮询时间上限，CLI 会返回已提交的回执，而不会错误地表示广播失败。
+添加 `--wait` 后，CLI 会轮询，直到交易确认或失败。如果先达到等待超时，命令返回 `submitted`；
+不使用 `--wait` 时，命令会在提交后立即返回。
 
-稍后广播已签名交易：
-
-```bash
-wallet-cli tx broadcast --tx-stdin < signed.json
-```
-
-`tx status` 返回四状态模型：`confirmed`、`failed`、`pending` 或 `not_found`。
+广播先前签名的交易文件：
 
 ```bash
+wallet-cli tx broadcast --file signed.hex --network tron:nile
 wallet-cli tx status --txid <TXID>
 wallet-cli tx info --txid <TXID> --output json
 ```
 
-CLI 还提供一个纯粹、可离线使用的签名器，用于签名在其他位置构建的交易：
+`tx sign` 的直接签名路径接受 JSON；为多签交易添加签名时，可以通过十六进制字符串或文件传入
+交易数据：
 
 ```bash
 wallet-cli tx sign --transaction "$TX_JSON"
+wallet-cli tx approvals --file transaction.hex --network tron:nile
+wallet-cli tx sign --file transaction.hex --out signed.hex --network tron:nile
 ```
 
-它始终验证 `txID` 是否为 `raw_data_hex` 的哈希，并验证声明的合约类型是否与编码后的交易一致。
-对于可以重新编码的合约类型，它还会验证 `raw_data` 的字段级内容。在多签工作流中，它会向已有的
-签名数组追加签名。详见[签名与安全](typescript-cli-signing.md#sign-an-existing-transaction)。
+使用十六进制或文件签名时，CLI 默认会在线检查所选权限和已有签名。在与网络隔离的签名设备上使用
+`--offline`，之后再通过 `tx approvals` 检查结果。详见[多签](typescript-cli-multisig.md)和
+[签名与安全](typescript-cli-signing.md)。
+
+## 权限与多签
+
+TRON 权限由带权重的签名密钥和阈值组成。创建交易前先查看当前权限，并在签名任何权限替换交易前
+进行试运行：
+
+```bash
+wallet-cli permission show --account main --network tron:nile
+wallet-cli permission update --file permissions.json --network tron:nile --dry-run
+wallet-cli tx approvals --file transaction.hex --network tron:nile
+```
+
+`permission update` 会替换完整的权限结构，并收取当前链上权限更新费。错误的 owner 权限可能会永久
+锁定账户。
+
+可选的 `tx multisig` 命令使用 TronLink 服务协调签名。该服务并非必需；签名者也可以直接交换交易
+文件。这两种工作流详见[多签](typescript-cli-multisig.md)。
 
 ## 查询
 
-与钱包绑定的账户查询默认使用 active account，也可以通过 `--account` 指定账户。
+与钱包绑定的查询默认使用活动账户，也可以通过 `--account` 选择其他账户。
 
 ```bash
 wallet-cli account info --output json
 wallet-cli account history --limit 10
 wallet-cli account portfolio
 wallet-cli networks
-wallet-cli block
 wallet-cli block 12345
 wallet-cli chain params
 wallet-cli chain prices
 wallet-cli chain node
 wallet-cli stake info
-wallet-cli stake delegated --direction out
 wallet-cli vote status
 wallet-cli reward balance
 ```
 
-有关字段级命令语义和更多示例，请参见
-[上游 TypeScript 命令参考](https://github.com/tronprotocol/wallet-cli/tree/master/ts/docs/commands)。
+所有支持的选项和响应字段，请参见
+[上游命令参考](https://github.com/tronprotocol/wallet-cli/tree/master/ts/docs/commands)。
 
 ## Token 和合约
 
-Token 地址簿内置了 USDT、USDC 等常见主网 token，也可以加入自定义 TRC-20 合约。
+Token 地址簿包含常用主网 token，也支持自定义 TRC-20 合约。
 
 ```bash
 wallet-cli token add --contract TR7...
@@ -187,7 +195,7 @@ wallet-cli token info --contract TR7...
 wallet-cli token remove --contract TR7...
 ```
 
-合约调用使用 JSON 编码的参数描述：
+合约调用使用 JSON 编码的参数：
 
 ```bash
 wallet-cli contract info --contract TR7...
@@ -211,16 +219,25 @@ wallet-cli contract deploy \
   --dry-run
 ```
 
-在 JSON 输出中，TypeScript CLI 的合约部署成功后，部署回执数据会包含部署出的 `contractAddress`。
+签名或广播合约部署交易需要软件账户。Ledger 账户可以使用 `--dry-run` 或 `--build-only`，因为这两种
+模式不会签名。
 
-当地址上没有已部署的合约时，`contract info` 会返回 not-found 错误，而不是返回空合约。
+## GasFree 转账
 
-合约部署需要软件账户。Ledger TRON app 无法签名 `CreateSmartContract`，因此 Ledger 支持的
-账户不能使用 `wallet-cli contract deploy`。
+GasFree 可以在账户没有 TRX 的情况下转移受支持的 token，服务费从转移的 token 中收取。
+
+```bash
+wallet-cli gasfree info --network tron:nile
+wallet-cli gasfree transfer --to T... --amount 25 --token USDT --network tron:nile --dry-run
+wallet-cli gasfree trace <TRACE_ID> --network tron:nile
+```
+
+GasFree 支持主网和 Nile，并要求配置服务凭据。提交请求后会返回 GasFree trace id；可以通过 `--wait`
+或 `gasfree trace` 跟踪。详见 [TypeScript CLI GasFree](typescript-cli-gasfree.md)。
 
 ## Stake 2.0
 
-质押金额以 SUN 为单位。TypeScript CLI 提供 Stake 2.0 命令：
+质押金额以 SUN 为单位。
 
 ```bash
 wallet-cli stake freeze --amount-sun 1000000 --resource energy --dry-run
@@ -233,14 +250,10 @@ wallet-cli stake info
 wallet-cli stake delegated --direction out
 ```
 
-`stake cancel-unfreeze` 需要软件账户；Ledger TRON app 无法签名 `CancelAllUnfreezeV2Contract`。
-
-`stake withdraw` 会在构建交易前检查可提取金额；如果没有已到期的解冻 TRX，则返回
-`nothing_to_withdraw`。
+签名或广播 `stake cancel-unfreeze` 需要软件账户。Ledger 账户可以使用 `--dry-run` 或
+`--build-only`，因为这两种模式不会签名。
 
 ## 投票和奖励
-
-TypeScript CLI 可以查看超级代表、替换账户的投票分配、查询可领取奖励并提取奖励：
 
 ```bash
 wallet-cli vote list
@@ -250,14 +263,30 @@ wallet-cli reward balance
 wallet-cli reward withdraw
 ```
 
-`vote cast` 会替换现有的完整投票分配，未列出的 SR 会被设为零票。`vote cast` 和
-`reward withdraw` 都会创建交易，因此需要签名账户。当可领取余额为空时，`reward withdraw` 返回
-`no_reward`；未满 24 小时的提取间隔时，则返回 `withdraw_too_frequent`。
+`vote cast` 会替换完整的投票分配，因此未列出的超级代表将不再获得投票。对 `vote cast` 或
+`reward withdraw` 进行签名或广播需要软件账户或 Ledger 账户；`--dry-run` 和 `--build-only` 不会签名。
+
+## 本地工具
+
+```bash
+wallet-cli contact add alice T... --note "Alice mainnet"
+wallet-cli contact list
+wallet-cli tx send --to alice --amount 1 --network tron:nile --dry-run
+wallet-cli contact remove alice
+
+wallet-cli address generate --out ./generated-keypair.json
+wallet-cli encoding convert T...
+wallet-cli current --qr
+```
+
+联系人保存在本地，可以作为 `tx send` 和 `gasfree transfer` 的收款方。`address generate` 会创建
+密钥对，但不会将其导入钱包。请保护生成的私钥文件，并且只在受控的离线终端中使用
+`--print-secret`。
 
 ## 签名
 
-除 `message sign` 外，CLI 还提供 `tx sign` 和 EIP-712/TIP-712 `typed-data sign`。软件账户和
-Ledger 账户均受支持；watch-only 账户会在写入或签名操作开始前失败。
+CLI 支持消息、交易以及 EIP-712/TIP-712 类型化数据签名。软件账户和 Ledger 账户可以签名；
+watch-only 账户不能签名。
 
 ```bash
 wallet-cli message sign --message 'hello'
@@ -265,28 +294,24 @@ wallet-cli tx sign --transaction "$TX_JSON"
 wallet-cli typed-data sign --typed-data "$TYPED_DATA_JSON"
 ```
 
-有关交易完整性检查、多签行为、Ledger 设置和 secret 输入规则，请参见
-[签名与安全](typescript-cli-signing.md)。
+有关密码输入、Ledger 设置、离线签名和交易检查，请参见[签名与安全](typescript-cli-signing.md)。
 
 ## 自动化
 
-JSON 模式向 stdout 输出一个 `wallet-cli.result.v1` envelope，并使用确定的退出码：
+JSON 输出使用单个 `wallet-cli.result.v1` 信封。退出码保持稳定：
 
 | 代码 | 含义 |
-|------|---------|
-| `0` | 成功。 |
-| `1` | 执行、鉴权、设备或链上错误。 |
-| `2` | 命令用法或参数无效。 |
+|------|------|
+| `0` | 命令成功完成。 |
+| `1` | 发生运行时错误或执行失败。 |
+| `2` | 命令用法、输入或配置错误。 |
 
-智能体和脚本可以发现完整命令目录与 JSON Schema，无需解析面向人的 help 文本：
+对于使用 `--wait` 的命令，请检查 `data.stage`：`"confirmed"` 和 `"failed"` 是最终结果，
+`"submitted"` 不是最终结果。
+
+脚本可以发现命令和 JSON Schema，而无需解析面向用户的帮助文本：
 
 ```bash
 wallet-cli --json-schema
 wallet-cli tx send --json-schema
 ```
-
-规范命令 ID 不带 `tron.` 前缀：例如命令 ID 是 `tx.send`，而不是 `tron.tx.send`。网络 family 则通过
-`chain.family` 单独提供。
-
-`--timeout 0` 或不受支持的 `--output` 值等无效全局选项会返回 `invalid_value`，而不是静默退回
-默认值。

--- a/docs/clients/wallet-cli/wallet-management.md
+++ b/docs/clients/wallet-cli/wallet-management.md
@@ -169,8 +169,7 @@ ChangePassword
     java -jar java/build/libs/wallet-cli.jar clear-wallet-keystore --force
     ```
 
-    - `--force` 在语法上是可选的，但在标准 CLI 模式下执行这一破坏性操作时必须提供 —— 不带它命令会
-      以用法错误失败。需要鉴权。
+    - 传入 `--force` 以确认这一破坏性操作。需要鉴权。
 
 === "交互模式"
 
@@ -215,18 +214,9 @@ ViewTransactionHistory
 
 ## 别名（仅标准 CLI）
 
-标准 CLI 支持**别名** —— 为账户和代币起的友好名称 —— 这样你可以写 `--to my-friend` 而不是原始的
-Base58 地址。别名按网络隔离，来自两层：一组**内置**别名（只读）和你的**用户**别名。
-
-别名解析作用于**地址**字段，而非数字 ID：
-
-- **账户别名**（`--type ACCOUNT`）作用于诸如 `--to`、`--from`、`--owner`、`--receiver`、
-  `--address` 等地址字段。
-- **代币别名**（`--type TOKEN`）作用于合约地址字段 —— 合约 `--contract` 选项，以及
-  `get-contract` / `get-contract-info` 的 `--address`。
-
-它们**不**作用于 TRC-10 资产 ID（`--asset`）或 `--token-id`，这些按数字 ID 原样读取。当别名被
-解析时，解析结果会在 JSON 模式下以 `meta.resolved` 上报。
+标准 CLI 支持按网络隔离的账户和代币地址别名，因此可以写 `--to my-friend`，而不必使用 Base58 地址。
+内置别名是只读的；用户别名可以添加和删除。账户别名作用于账户地址选项，代币别名作用于合约地址选项。
+别名不作用于数字形式的 TRC-10 资产 ID 或 `--token-id`。
 
 ```bash
 # 添加账户别名

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -290,6 +290,8 @@ nav:
                 - 查询: clients/wallet-cli/query.md
             - TypeScript / npm CLI:
                 - 概览: clients/wallet-cli/typescript-cli.md
+                - 多签: clients/wallet-cli/typescript-cli-multisig.md
+                - GasFree: clients/wallet-cli/typescript-cli-gasfree.md
                 - 签名与安全: clients/wallet-cli/typescript-cli-signing.md
     - 版本发布:
         - 新版本部署手册: releases/upgrade-instruction.md


### PR DESCRIPTION
## Summary

- translate the wallet-cli v4.11.0 documentation updates for the Chinese site
- add TypeScript CLI multi-signature and GasFree documentation
- align the simplified TypeScript and Java CLI guidance with the English documentation

## Validation

- verified with mkdocs build --strict
- checked with git diff --check