### PR TITLE
align docs with java-tron v4.8.2.1

### DIFF
--- a/docs/developers/network.md
+++ b/docs/developers/network.md
@@ -30,8 +30,6 @@ P2P网络作为TRON的最底层模块，直接决定了整个区块链网络的�
 
 其中**节点发现**与**节点连接**这两部分的底层实现已从 java-tron 仓库抽离为独立的外部依赖 [`io.github.tronprotocol:libp2p`](https://github.com/tronprotocol/libp2p)，由该库负责底层的节点发现（基于 Kademlia 算法）与连接传输，并新增了基于 DNS 的节点发现等能力。其上的 TRON 协议层——包括 P2P_HELLO 握手、P2P_PING/P2P_PONG 保活、peer 业务状态管理、消息分发、同步与广播——仍由 java-tron 的 `core/net` 实现，并通过 `TronNetService` 与 libp2p 对接。底层节点发现与连接的实现细节请参阅 libp2p 仓库，本文不再展开。
 
-从 libp2p v2.2.9 开始，处理异常对等节点握手消息时的日志输出受到限制，以减少日志过度增长和内存占用。
-
 而**区块同步**与**区块和交易广播**仍由 java-tron 的 `core/net` 实现，下面分别介绍这两个功能部分。
 
 ## 对等节点连接管理 { #peer-connection-management }

--- a/docs/developers/network.md
+++ b/docs/developers/network.md
@@ -30,6 +30,8 @@ P2P网络作为TRON的最底层模块，直接决定了整个区块链网络的�
 
 其中**节点发现**与**节点连接**这两部分的底层实现已从 java-tron 仓库抽离为独立的外部依赖 [`io.github.tronprotocol:libp2p`](https://github.com/tronprotocol/libp2p)，由该库负责底层的节点发现（基于 Kademlia 算法）与连接传输，并新增了基于 DNS 的节点发现等能力。其上的 TRON 协议层——包括 P2P_HELLO 握手、P2P_PING/P2P_PONG 保活、peer 业务状态管理、消息分发、同步与广播——仍由 java-tron 的 `core/net` 实现，并通过 `TronNetService` 与 libp2p 对接。底层节点发现与连接的实现细节请参阅 libp2p 仓库，本文不再展开。
 
+从 libp2p v2.2.9 开始，处理异常对等节点握手消息时的日志输出受到限制，以减少日志过度增长和内存占用。
+
 而**区块同步**与**区块和交易广播**仍由 java-tron 的 `core/net` 实现，下面分别介绍这两个功能部分。
 
 ## 对等节点连接管理 { #peer-connection-management }

--- a/docs/using_javatron/configuration.md
+++ b/docs/using_javatron/configuration.md
@@ -148,6 +148,8 @@ storage {
 - `node.jsonrpc.maxMessageSize` 控制 JSON-RPC 请求体大小。
 - `node.jsonrpc.maxBatchSize`、`maxResponseSize` 和 filter 限制用于约束 JSON-RPC 工作负载。
 
+`node.rpc.maxConcurrentCallsPerConnection` 用于限制单个连接上的 gRPC 并发调用数。默认值为 `100`，设置为 `0` 时同样使用 `100`。如果客户端需要在单个连接上发起超过 100 个并发调用，请将该值配置为大于 `100` 的正整数。
+
 使用 `node.disabledApi` 可以禁用指定的 HTTP、gRPC 或 PBFT 方法，但它不会禁用 JSON-RPC 方法；要禁用 JSON-RPC 服务，请使用对应的 `node.jsonrpc.*Enable` 开关。
 
 不要将管理类接口或交易构造接口直接暴露给不受信任的网络。应通过主机或网络控制限制访问，并在需要时将公共服务置于配置适当的网关之后。有关各协议的具体行为，请参阅 [HTTP API](../api/http/index.md) 和 [JSON-RPC API](../api/json-rpc/index.md) 指南。


### PR DESCRIPTION
## Summary

- document the libp2p v2.2.9 logging improvement for abnormal peer handshake messages
- document the gRPC per-connection concurrent call limit and its default behavior

## Testing

- mkdocs build --strict