### PR TITLE
align docs with java-tron v4.8.2.2

### DIFF
--- a/docs/api/http/smart-contract/deploycontract.md
+++ b/docs/api/http/smart-contract/deploycontract.md
@@ -11,7 +11,7 @@
 | 字段 | 类型 | 必填 | 说明 |
 |---|---|---|---|
 | `owner_address` | string | 是 | 部署者地址 |
-| `name` | string | 否 | 合约名 |
+| `name` | string | 否 | 合约名，不得超过 32 字节。`VERSION_4_8_2_2` 升级生效后，该限制按 UTF-8 编码后的字节数计算 |
 | `abi` | json string | 否 | 合约 ABI（JSON 数组字符串） |
 | `bytecode` | string | 是 | 合约字节码（hex） |
 | `parameter` | string | 否 | 构造函数参数（hex，紧接 bytecode） |
@@ -102,4 +102,4 @@ curl --request POST \
 | `consume_user_resource_percent` 不在 [0, 100] | `{"Error": "class org.tron.core.exception.ContractValidateException : percent must be >= 0 and <= 100"}` |
 | 其他异常 | `{"Error": "<exceptionClass> : <message>"}` |
 
-> 部署逻辑（如 origin energy 不足、合约代码超长、构造函数 revert）在交易广播或上链阶段才会触发，不会在此接口直接返回。
+> 部署阶段的错误（例如 origin energy 不足、合约代码或合约名超长、构造函数 revert）只会在交易广播或区块打包时触发，不会由此接口在构造未签名交易时触发。

--- a/docs/api/json-rpc/tx-build/buildTransaction.md
+++ b/docs/api/json-rpc/tx-build/buildTransaction.md
@@ -24,7 +24,7 @@ Tron 私有扩展。构造一条**未签名**的 Tron 交易；签名后通过 H
 | `tokenId` | `0` | TRC-10 token id（用于 `TransferAssetContract`） |
 | `tokenValue` | `0` | TRC-10 数量 |
 | `abi` | `""` | 部署合约时的 ABI JSON 字符串（如 `[{...}]`） |
-| `name` | `""` | 部署合约名 |
+| `name` | `""` | 部署合约名，不得超过 32 字节。`VERSION_4_8_2_2` 升级生效后，该限制按 UTF-8 编码后的字节数计算 |
 | `consumeUserResourcePercent` | `0` | 用户分担资源百分比（0–100） |
 | `originEnergyLimit` | `0` | 部署者每笔最大 energy |
 | `permissionId` | `0` | 多签 permission id |

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -5,8 +5,8 @@
   "description": "Machine-readable definition generated from java-tron source code, with human-facing metadata linked to the markdown API documentation."
   "x-java-tron-source":
     "repo": "tronprotocol/java-tron"
-    "commit": "f8ff7c76f45ab41d9bb76922329657506819701b"
-    "version": "GreatVoyage-v4.8.2"
+    "commit": "d5c3d1d1fd0cad12f09c4346d6ac937ab2cbb071"
+    "version": "GreatVoyage-v4.8.2.2"
 "servers":
   -
     "url": "https://nile.trongrid.io"
@@ -13256,7 +13256,7 @@
           "description": "Percentage of contract execution resource cost paid by the user."
         "name":
           "type": "string"
-          "description": "Name encoded as expected by java-tron."
+          "description": "Contract name. It must not exceed 32 bytes. After the VERSION_4_8_2_2 upgrade takes effect, the limit is measured using UTF-8 encoding, not by the number of characters."
         "origin_energy_limit":
           "type": "integer"
           "format": "int64"
@@ -14261,7 +14261,7 @@
           "description": "Contract parameter payload."
         "name":
           "type": "string"
-          "description": "Name encoded as expected by java-tron."
+          "description": "Contract name. It must not exceed 32 bytes. After the VERSION_4_8_2_2 upgrade takes effect, the limit is measured using UTF-8 encoding, not by the number of characters."
         "call_value":
           "type": "integer"
           "format": "int64"
@@ -16669,7 +16669,7 @@
           "description": "Percentage of contract execution resource cost paid by the user."
         "name":
           "type": "string"
-          "description": "Name encoded as expected by java-tron."
+          "description": "Contract name. It must not exceed 32 bytes. After the VERSION_4_8_2_2 upgrade takes effect, the limit is measured using UTF-8 encoding, not by the number of characters."
         "origin_energy_limit":
           "oneOf":
             -

--- a/docs/api/openrpc.json
+++ b/docs/api/openrpc.json
@@ -6,8 +6,8 @@
     "description": "Machine-readable definition generated from java-tron source code, with human-facing metadata linked to the markdown API documentation.",
     "x-java-tron-source": {
       "repo": "tronprotocol/java-tron",
-      "commit": "f8ff7c76f45ab41d9bb76922329657506819701b",
-      "version": "GreatVoyage-v4.8.2"
+      "commit": "d5c3d1d1fd0cad12f09c4346d6ac937ab2cbb071",
+      "version": "GreatVoyage-v4.8.2.2"
     }
   },
   "servers": [
@@ -2328,7 +2328,7 @@
               },
               "name": {
                 "type": "string",
-                "description": "Name encoded as expected by java-tron."
+                "description": "Contract name for deployment. It must not exceed 32 bytes. After the VERSION_4_8_2_2 upgrade takes effect, the limit is measured using UTF-8 encoding, not by the number of characters."
               },
               "permissionId": {
                 "type": "integer",

--- a/docs/api/rpc/smart-contract/DeployContract.md
+++ b/docs/api/rpc/smart-contract/DeployContract.md
@@ -8,4 +8,8 @@
 rpc DeployContract (CreateSmartContract) returns (TransactionExtention) {}
 ```
 
+构造 `CreateSmartContract` 时，请确保 `new_contract.name` 不超过 32 字节。`VERSION_4_8_2_2` 升级生效后，该限制按 UTF-8 编码后的字节数计算，而不是按字符数计算。例如，大多数汉字在 UTF-8 编码中各占三个字节。
+
+请将 `new_contract.code_hash` 和 `new_contract.trx_hash` 留空。这两个字段预留给节点设置；`VERSION_4_8_2_2` 升级生效后，如果任一字段非空，部署将失败。
+
 相似 HTTP 接口见 [/wallet/deploycontract](../../http/smart-contract/deploycontract.md)。

--- a/docs/api/specs/json-rpc/buildTransaction.json
+++ b/docs/api/specs/json-rpc/buildTransaction.json
@@ -98,7 +98,7 @@
           },
           "name": {
             "type": "string",
-            "description": "Name encoded as expected by java-tron."
+            "description": "Contract name for deployment. It must not exceed 32 bytes. After the VERSION_4_8_2_2 upgrade takes effect, the limit is measured using UTF-8 encoding, not by the number of characters."
           },
           "permissionId": {
             "type": "integer",

--- a/docs/clients/wallet-cli/java/commands/contract.md
+++ b/docs/clients/wallet-cli/java/commands/contract.md
@@ -9,7 +9,7 @@
 ```
 
 - `OwnerAddress`——发起交易的账户地址，可选，默认为登录账户的地址。
-- `contractName`——智能合约的名称。
+- `contractName`——智能合约的名称，最长 32 字节。`VERSION_4_8_2_2` 升级生效后，该限制按 UTF-8 编码后的字节数计算，而不是按字符数计算。
 - `ABI`——编译生成的 ABI 代码。
 - `byteCode`——编译生成的字节码。
 - `constructor`、`params`、`isHex`——定义字节码的格式，决定从参数解析 `byteCode` 的方式。

--- a/docs/contracts/contract.md
+++ b/docs/contracts/contract.md
@@ -70,10 +70,10 @@ message SmartContract {
 - `bytecode`：合约字节码
 - `call_value`：随合约调用传入的 TRX 金额
 - `consume_user_resource_percent`：开发者设置的调用者的资源扣费百分比
-- `name`：合约名称
+- `name`：合约名称，不得超过 32 字节。`VERSION_4_8_2_2` 升级生效后，该限制按 UTF-8 编码后的字节数计算，而不是按字符数计算
 - `origin_energy_limit`：开发者设置的在一次合约调用过程中自己消耗的 energy 的上限，必须大于 0。对于之前老的合约，deploy 的时候没有提供设置该值的参数，会存成 0，但是会按照 1000 万 energy 上限计算，开发者可以通过 `updateEnergyLimit` 接口重新设置该值，设置新值时也必须大于 0
-- `code_hash`：合约 runtime bytecode 的哈希
-- `trx_hash`：合约部署的根交易 id。仅对通过 `CREATE2` 操作码部署的合约填充该字段；通过 `CREATE` 操作码或 gRPC `deployContract` 部署的合约该字段为空
+- `code_hash`：已部署合约运行时字节码的哈希。节点会自动计算该字段的值，因此构造 `CreateSmartContract` 消息时必须将该字段留空。`VERSION_4_8_2_2` 升级生效后，提供非空值会导致部署失败
+- `trx_hash`：对于通过 TVM `CREATE2` 操作码创建的合约，节点会将该字段设置为根交易 ID。对于通过 `CREATE` 或 `DeployContract` API 创建的合约，该字段保持为空。构造 `CreateSmartContract` 消息时必须将该字段留空；`VERSION_4_8_2_2` 升级生效后，提供非空值会导致合约部署失败
 - `version`：合约版本号。当网络激活了 `ALLOW_TVM_COMPATIBLE_EVM` 提案后，新部署的合约会被标记为 version 1，使运行时可以仅对这些合约启用 EVM 兼容行为；激活前部署的旧合约保持 version 0，沿用原 TVM 语义。截至撰写时该提案在主网尚未激活，因此主网上所有合约的 version 都是 0
 
 通过另外两个 grpc message 类型 `CreateSmartContract` 和 `TriggerSmartContract` 来创建和使用 smart contract

--- a/docs/developers/workflows.md
+++ b/docs/developers/workflows.md
@@ -8,14 +8,13 @@
 | --- | --- | --- | --- |
 | PR Check（`pr-check.yml`） | `develop`、`release_**` | 运行 | 推送到 `master` 或 `release_**` |
 | PR Build（`pr-build.yml`） | `master`、`develop`、`release_**` | 跳过 | 手动触发 |
-| 单节点集成测试（`integration-test-single-node.yml`） | `develop`、`release_**` | 跳过 | 推送到 `master` 或 `release_**`；手动触发 |
-| 多节点集成测试（`integration-test-multinode.yml`） | `develop`、`release_**` | 跳过 | 推送到 `master` 或 `release_**`；手动触发 |
+| 单节点冒烟集成测试（`integration-test-single-node.yml`） | `develop`、`release_**` | 跳过 | 推送到 `master` 或 `release_**`；手动触发 |
 | CodeQL（`codeql.yml`） | `develop` | 跳过 | 推送到 `develop`、`master` 或 `release_**`；每周定时运行 |
 | Math 使用检查（`math-check.yml`） | `develop`、`release_**` | 运行 | 推送到 `master` 或 `release_**`；手动触发 |
 | 审查者分配（`pr-reviewer.yml`） | `develop`、`release_**` | 运行 | 无 |
 | 关闭 PR 时取消工作流（`pr-cancel.yml`） | 任意分支 | 未合并的 PR 关闭时运行 | 无 |
 
-如果 Pull Request 仅修改文档或部分仓库元数据文件，PR Build、两个集成测试工作流和 CodeQL 会被跳过。如果同一 Pull Request 还包含其他文件，符合目标分支条件的工作流会正常运行。PR Check、Math 使用检查、审查者分配和关闭时取消工作流没有此路径排除规则。
+如果 Pull Request 仅修改文档或部分仓库元数据文件，PR Build、单节点冒烟集成测试工作流和 CodeQL 会被跳过。如果同一 Pull Request 还包含其他文件，符合目标分支条件的工作流会正常运行。PR Check、Math 使用检查、审查者分配和关闭时取消工作流没有此路径排除规则。
 
 ## PR 校验和代码检查
 
@@ -48,12 +47,9 @@
 
 ## 集成、安全和 Math 检查
 
-本套文档对应的源码版本包含两个完整集成测试工作流：
+本套文档对应的源码版本包含一个单节点集成测试工作流，它针对一个节点运行冒烟测试子集。GitHub Actions 不会运行完整的单节点测试集和多节点集成测试工作流。
 
-- 单节点工作流针对一个节点运行完整测试集。
-- 多节点工作流针对由三个见证节点组成的环境运行完整测试集。
-
-它们会针对目标为 `develop` 或 `release_**` 且符合路径条件的 PR 运行，也会在推送到 `master` 或 `release_**` 时运行，并且支持手动触发。
+该冒烟测试工作流会针对目标为 `develop` 或 `release_**` 且符合路径条件的 PR 运行，也会在推送到 `master` 或 `release_**` 时运行，并且支持手动触发。
 
 CodeQL 仅针对目标为 `develop` 的 PR 运行。此外，它还会在推送到 `develop`、`master` 或 `release_**` 时运行，并且每周定时运行。
 
@@ -77,8 +73,7 @@ PR 校验和审查者分配使用不同的 `scope` 列表。PR 校验的已知�
 
 - PR Build
 - CodeQL
-- 单节点集成测试
-- 多节点集成测试
+- 单节点冒烟集成测试
 
 ## Sonar 配置
 


### PR DESCRIPTION
## Summary

- align the Chinese CI workflow documentation with the current single-node smoke test setup
- document the 32-byte contract-name limit and VERSION_4_8_2_2 activation behavior
- clarify the node-populated code_hash and trx_hash fields
- sync the OpenAPI and OpenRPC definitions with the English repository

## Validation

- mkdocs build --strict